### PR TITLE
userAgent: Standardize userAgent with the new style.

### DIFF
--- a/src/main/errors.js
+++ b/src/main/errors.js
@@ -14,6 +14,13 @@
  * limitations under the License.
  */
 
+export class InvalidArgumentException extends Error {
+  constructor(message) {
+    super(message)
+    this.name = 'InvalidArgumentException'
+  }
+}
+
 export class InvalidBucketNameException extends Error {
   constructor(message) {
     super(message)
@@ -53,13 +60,6 @@ export class ExpiresParamException extends Error {
   constructor(message) {
     super(message)
     this.name = 'ExpiresParamException'
-  }
-}
-
-export class InvalidUserAgentException extends Error {
-  constructor(message) {
-    super(message)
-    this.name = 'InvalidUserAgentException'
   }
 }
 

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -72,14 +72,23 @@ export default class Client extends Multipart {
           }
       }
     }
+
+    // User Agent should always following the below style.
+    // Please open an issue to discuss any new changes here.
+    //
+    //       Minio (OS; ARCH) LIB/VER APP/VER
+    //
+    var libraryComments = `(${process.platform}; ${process.arch})`
+    var libraryAgent = `Minio ${libraryComments} minio-js/${Package.version}`
+    // User agent block ends.
+
     var newParams = {
       host: host,
       port: port,
       protocol: protocol,
       accessKey: params.accessKey,
       secretKey: params.secretKey,
-      userAgent: `minio-js/${Package.version} (${process.platform}; ${process.arch})`,
-      userAgentSet: false
+      userAgent: `${libraryAgent}`,
     }
     super(newParams, transport)
     this.params = newParams
@@ -88,21 +97,29 @@ export default class Client extends Multipart {
 
   // CLIENT LEVEL CALLS
 
-  setUserAgent(name, version, comments) {
-    var formattedComments = ''
-    if (comments && comments.length > 0) {
-      var joinedComments = comments.join('; ')
-      formattedComments = ` (${joinedComments})`
+  // Set application specific information.
+  //
+  // Generates User-Agent in the following style.
+  //
+  //       Minio (OS; ARCH) LIB/VER APP/VER
+  //
+  // __Arguments__
+  // * `appName` _string_ - Application name.
+  // * `appVersion` _string_ - Application version.
+  setAppInfo(appName, appVersion) {
+    if (!isString(appName)) {
+      throw new TypeError(`Invalid appName: ${appName}`)
     }
-    if (this.params.userAgentSet) {
-      throw new errors.InternalClientException('user agent already set')
+    if (appName.trim() === '') {
+      throw new errors.InvalidArgumentException('Input appName cannot be empty.')
     }
-    if (name && version) {
-      this.params.userAgent = `${this.params.userAgent} ${name}/${version}${formattedComments}`
-      this.params.userAgentSet = true
-    } else {
-      throw new errors.InvalidUserAgentException('Invalid user agent')
+    if (!isString(appVersion)) {
+      throw new TypeError(`Invalid appName: ${appVersion}`)
     }
+    if (appVersion.trim() === '') {
+      throw new errors.InvalidArgumentException('Input appVersion cannot be empty.')
+    }
+    this.params.userAgent = `${this.params.userAgent} ${appName}/${appVersion}`
   }
 
   // SERVICE LEVEL CALLS

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -184,7 +184,8 @@ describe('Client', () => {
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
-      assert.equal(`minio-js/${Package.version} (${process.platform}; ${process.arch})`, client.params.userAgent)
+      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version}`,
+                   client.params.userAgent)
     })
     it('should set user agent', () => {
       var client = new Minio({
@@ -192,8 +193,9 @@ describe('Client', () => {
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
-      client.setUserAgent('test', '1.0.0', ['comment', 'arch', 'os'])
-      assert.equal(`minio-js/${Package.version} (${process.platform}; ${process.arch}) test/1.0.0 (comment; arch; os)`, client.params.userAgent)
+      client.setAppInfo('test', '1.0.0')
+      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version} test/1.0.0`,
+                   client.params.userAgent)
     })
     it('should set user agent without comments', () => {
       var client = new Minio({
@@ -201,8 +203,9 @@ describe('Client', () => {
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
-      client.setUserAgent('test', '1.0.0', [])
-      assert.equal(`minio-js/${Package.version} (${process.platform}; ${process.arch}) test/1.0.0`, client.params.userAgent)
+      client.setAppInfo('test', '1.0.0')
+      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version} test/1.0.0`,
+                   client.params.userAgent)
     })
     it('should not set user agent without name', (done) => {
       try {
@@ -211,7 +214,7 @@ describe('Client', () => {
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
-        client.setUserAgent(null, '1.0.0')
+        client.setAppInfo(null, '1.0.0')
       } catch (e) {
         done()
       }
@@ -223,7 +226,7 @@ describe('Client', () => {
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
-        client.setUserAgent('', '1.0.0')
+        client.setAppInfo('', '1.0.0')
       } catch (e) {
         done()
       }
@@ -235,7 +238,7 @@ describe('Client', () => {
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
-        client.setUserAgent('test', null)
+        client.setAppInfo('test', null)
       } catch (e) {
         done()
       }
@@ -247,21 +250,7 @@ describe('Client', () => {
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
-        client.setUserAgent('test', '')
-      } catch (e) {
-        done()
-      }
-    })
-    it('should not set user agent twice', (done) => {
-      try {
-        var client = new Minio({
-          endPoint: 'https://localhost:9000',
-          accessKey: 'accesskey',
-          secretKey: 'secretkey'
-        })
-        client.setUserAgent('test', '1.0.0')
-        assert.equal(`minio-js/${Package.version} (${process.platform}; ${process.arch}) test/1.0.0`, client.params.userAgent)
-        client.setUserAgent('test', '1.0.0')
+        client.setAppInfo('test', '')
       } catch (e) {
         done()
       }


### PR DESCRIPTION
- Rename setUserAgent as setAppInfo(appName, appVersion).
  No other comments can be added by the application.
- Fixes all the tests as well.

Fixes #351