### PR TITLE
arguments: Take arguments like other libraries and validate them.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ node_js:
 - '0.10'
 - '0.11'
 - '0.12'
+- '4.2.4'
 script:
 - gulp browserify
 - gulp lint

--- a/API.md
+++ b/API.md
@@ -6,7 +6,7 @@ Minio client object is created using minio-js:
 var Minio = require('minio')
 
 var s3Client = new Minio({
-  endPoint:  'https://s3.amazonaws.com',
+  endPoint:  's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ npm install --save minio
 var Minio = require('minio')
 
 var s3client = new Minio({
-  endPoint:  'https://s3.amazonaws.com',
+  endPoint:  's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
@@ -48,7 +48,7 @@ s3client.listBuckets(function(e, bucketStream) {
     <script type="text/javascript" src="<your-cdn>/minio-browser.js"></script>
     <script>
      var s3Client = new Minio({
-      endPoint:  'https://s3.amazonaws.com',
+      endPoint:  's3.amazonaws.com',
       accessKey: 'YOUR-ACCESSKEYID',
       secretKey: 'YOUR-SECRETACCESSKEY'
      });

--- a/examples/bucket-exists.js
+++ b/examples/bucket-exists.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/fget-object.js
+++ b/examples/fget-object.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/fput-object.js
+++ b/examples/fput-object.js
@@ -24,7 +24,7 @@ var Fs = require('fs')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/get-bucket-acl.js
+++ b/examples/get-bucket-acl.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/get-object.js
+++ b/examples/get-object.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/get-partialobject.js
+++ b/examples/get-partialobject.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/list-buckets.js
+++ b/examples/list-buckets.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/list-incomplete-uploads.js
+++ b/examples/list-incomplete-uploads.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-    endPoint: 'https://s3.amazonaws.com',
+    endPoint: 's3.amazonaws.com',
     accessKey: 'YOUR-ACCESSKEYID',
     secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/list-objects.js
+++ b/examples/list-objects.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/make-bucket.js
+++ b/examples/make-bucket.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/presigned-getobject.js
+++ b/examples/presigned-getobject.js
@@ -23,9 +23,10 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
-  secretKey: 'YOUR-SECRETACCESSKEY'
+  secretKey: 'YOUR-SECRETACCESSKEY',
+  insecure: false // Default is false.
 })
 // Presigned get object URL for object name my-bucketname, it expires in 7 days by default.
 var presignedUrl = s3Client.presignedGetObject('my-bucketname', 'my-objectname', 1000, function(e, presignedUrl) {

--- a/examples/presigned-postpolicy.js
+++ b/examples/presigned-postpolicy.js
@@ -22,9 +22,10 @@ var Minio = require('minio')
 // find out your s3 end point here:
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
-  secretKey: 'YOUR-SECRETACCESSKEY'
+  secretKey: 'YOUR-SECRETACCESSKEY',
+  insecure: false // Default is false.
 })
 
 // Construct a new postPolicy.

--- a/examples/presigned-putobject.js
+++ b/examples/presigned-putobject.js
@@ -23,9 +23,10 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
-  secretKey: 'YOUR-SECRETACCESSKEY'
+  secretKey: 'YOUR-SECRETACCESSKEY',
+  insecure: false // Default is false.
 })
 
 var presignedUrl = s3Client.presignedPutObject('my-bucketname', 'my-objectname', 1000, function(e, presignedUrl) {

--- a/examples/put-object.js
+++ b/examples/put-object.js
@@ -24,7 +24,7 @@ var Fs = require('fs')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/remove-bucket.js
+++ b/examples/remove-bucket.js
@@ -23,7 +23,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/remove-incomplete-upload.js
+++ b/examples/remove-incomplete-upload.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/remove-object.js
+++ b/examples/remove-object.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/set-bucket-acl.js
+++ b/examples/set-bucket-acl.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/examples/stat-object.js
+++ b/examples/stat-object.js
@@ -24,7 +24,7 @@ var Minio = require('minio')
 // http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region
 
 var s3Client = new Minio({
-  endPoint: 'https://s3.amazonaws.com',
+  endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })

--- a/src/main/errors.js
+++ b/src/main/errors.js
@@ -29,6 +29,12 @@ export class InvalidArgumentError extends ExtendableError {
   }
 }
 
+export class InvalidPortError extends ExtendableError {
+  constructor(message) {
+    super(message)
+  }
+}
+
 export class InvalidEndPointError extends ExtendableError {
   constructor(message) {
     super(message)

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -15,6 +15,7 @@
  */
 
 import stream from 'stream'
+import _ from 'lodash'
 
 export function uriEscape(string) {
   var output = string
@@ -40,6 +41,71 @@ export function uriResourceEscape(string) {
 
 export function getScope(region, date) {
   return `${date.format('YYYYMMDD')}/${region}/s3/aws4_request`
+}
+
+// isAmazonEndpoint - true if endpoint is 's3.amazonaws.com'.
+export function isAmazonEndpoint(endpoint) {
+  return endpoint === 's3.amazonaws.com'
+}
+
+// isValidEndpoint - true if endpoint is valid domain.
+export function isValidEndpoint(endpoint) {
+  if (!isValidDomain(endpoint)) {
+    return false
+  }
+  // Endpoint matches amazon, make sure its 's3.amazonaws.com'
+  if (endpoint.match('.amazonaws.com$')) {
+    if (!isAmazonEndpoint(endpoint)) {
+      return false
+    }
+  }
+  // Returning true for all other cases.
+  return true
+}
+
+// isValidDomain - true if input host is a valid domain.
+export function isValidDomain(host) {
+  if (!isString(host)) return false
+  // See RFC 1035, RFC 3696.
+  if (host.length === 0 || host.length > 255) {
+    return false
+  }
+  // Host cannot start or end with a '-'
+  if (host[0] === '-' || host.substr(-1) === '-') {
+    return false
+  }
+  // Host cannot start or end with a '_'
+  if (host[0] === '_' || host.substr(-1) === '_') {
+    return false
+  }
+  // Host cannot start or end with a '.'
+  if (host[0] === '.' || host.substr(-1) === '.') {
+    return false
+  }
+  var alphaNumerics = '`~!@#$%^&*()+={}[]|\\\"\';:><?/'.split('')
+  // All non alphanumeric characters are invalid.
+  for (var i in alphaNumerics) {
+    if (host.indexOf(alphaNumerics[i]) > -1) {
+      return false
+    }
+  }
+  // No need to regexp match, since the list is non-exhaustive.
+  // We let it be valid and fail later.
+  return true
+}
+
+// isValidPort - is input port valid.
+export function isValidPort(port) {
+  // verify if port is a number.
+  if (!isNumber(port)) return false
+  // port cannot be negative.
+  if (port < 0) return false
+  // port '0' is valid and special case return true.
+  if (port === 0) return true
+  var min_port = 1;
+  var max_port = 65535;
+  // Verify if port is in range.
+  return port >= min_port && port <= max_port
 }
 
 export function isValidBucketName(bucket) {
@@ -73,11 +139,6 @@ export function isValidPrefix(prefix) {
 // check for allowed ACLs
 export function isValidACL(acl) {
   return acl === 'private' || acl === 'public-read' || acl === 'public-read-write' || acl === 'authenticated-read'
-}
-
-// check if typeof arg boolean
-export function isBoolean(arg) {
-  return typeof(arg) === 'boolean'
 }
 
 // check if typeof arg number

--- a/src/main/signing.js
+++ b/src/main/signing.js
@@ -217,12 +217,10 @@ export function signV4(request, dataShaSum256, accessKey, secretKey, region, req
 
   var headers = _.assign({}, request.headers)
 
-  var host = request.host
-
+  headers.host = request.host
   if ((request.protocol === 'http:' && request.port !== 80) || (request.protocol === 'https:' && request.port !== 443)) {
-    host = `${host}:${request.port}`
+    headers.host = `${request.host}:${request.port}`
   }
-  headers.host = host
   headers['x-amz-date'] = requestDate.format('YYYYMMDDTHHmmss') + 'Z'
   headers['x-amz-content-sha256'] = dataShaSum256
 

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -31,7 +31,7 @@ require('source-map-support').install()
 describe('functional tests', function() {
   this.timeout(30*60*1000)
   var client = new minio({
-    endPoint: 'https://s3.amazonaws.com',
+    endPoint: 's3.amazonaws.com',
     accessKey: process.env['KEY'],
     secretKey: process.env['SECRET']
   })
@@ -66,8 +66,8 @@ describe('functional tests', function() {
 
   var traceStream
 
-  // FUNCTIONAL_TEST_TRACE env varialble contains the path to which trace
-  // will be logged. Set it to /dev/stdout log to the stdou.
+  // FUNCTIONAL_TEST_TRACE env variable contains the path to which trace
+  // will be logged. Set it to /dev/stdout log to the stdout.
   if (process.env['FUNCTIONAL_TEST_TRACE']) {
     var filePath = process.env['FUNCTIONAL_TEST_TRACE']
     // This is necessary for windows.

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -51,42 +51,70 @@ describe('Client', function() {
       return request
     },
     client = new Minio({
-      endPoint: 'http://localhost:9000',
+      endPoint: 'localhost',
+      port: 9000,
       accessKey: 'accesskey',
-      secretKey: 'secretkey'
+      secretKey: 'secretkey',
+      insecure: true
     })
   describe('new client', () => {
     it('should work with http', () => {
       var client = new Minio({
-        endPoint: 'http://localhost',
-        accessKey: 'accesskey',
-        secretKey: 'secretkey'
-      })
-      assert.equal(client.params.port, 80)
-    })
-    it('should override port with http', () => {
-      var client = new Minio({
-        endPoint: 'http://localhost:9000',
-        accessKey: 'accesskey',
-        secretKey: 'secretkey'
-      })
-      assert.equal(client.params.port, 9000)
-    })
-    it('should work with https', () => {
-      var client = new Minio({
-        endPoint: 'https://localhost',
+        endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
       assert.equal(client.params.port, 443)
     })
+    it('should override port with http', () => {
+      var client = new Minio({
+        endPoint: 'localhost',
+        port: 9000,
+        accessKey: 'accesskey',
+        secretKey: 'secretkey',
+        insecure: true
+      })
+      assert.equal(client.params.port, 9000)
+    })
+    it('should work with https', () => {
+      var client = new Minio({
+        endPoint: 'localhost',
+        accessKey: 'accesskey',
+        secretKey: 'secretkey',
+        insecure: true
+      })
+      assert.equal(client.params.port, 80)
+    })
     it('should override port with https', () => {
       var client = new Minio({
-        endPoint: 'https://localhost:9000',
+        endPoint: 'localhost',
+        port: 9000,
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
       assert.equal(client.params.port, 9000)
+    })
+    it('should fail with url', (done) => {
+      try {
+        new Minio({
+          endPoint: 'http://localhost:9000',
+          accessKey: 'accesskey',
+          secretKey: 'secretkey'
+        })
+      } catch (e) {
+        done()
+      }
+    })
+    it('should fail with alphanumeric', (done) => {
+      try {
+        new Minio({
+          endPoint: 'localhost##$@3',
+          accessKey: 'accesskey',
+          secretKey: 'secretkey'
+        })
+      } catch (e) {
+        done()
+      }
     })
     it('should fail with no url', (done) => {
       try {
@@ -98,10 +126,11 @@ describe('Client', function() {
         done()
       }
     })
-    it('should fail with no scheme', (done) => {
+    it('should fail with bad port', (done) => {
       try {
         new Minio({
           endPoint: 'localhost',
+          port: -1,
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -115,7 +144,8 @@ describe('Client', function() {
       it('should not generate presigned url with no access key', (done) => {
         try {
           var client = new Minio({
-            endPoint: 'https://localhost:9000',
+            endPoint: 'localhost',
+            port: 9000
           })
           client.presignedGetObject('bucket', 'object', '1000')
         } catch (e) {
@@ -125,7 +155,8 @@ describe('Client', function() {
       it('should not generate presigned url with wrong expires param', (done) => {
         try {
           var client = new Minio({
-            endPoint: 'https://localhost:9000',
+            endPoint: 'localhost',
+            port: 9000,
             accessKey: 'accesskey',
             secretKey: 'secretkey',
           })
@@ -136,7 +167,8 @@ describe('Client', function() {
       })
       it('should generate presigned url', (done) => {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
+          port: 9000,
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -150,7 +182,8 @@ describe('Client', function() {
       it('should not generate presigned url with no access key', (done) => {
         try {
           var client = new Minio({
-            endPoint: 'https://localhost:9000',
+            endPoint: 'localhost',
+            port: 9000,
           })
           client.presignedPutObject('bucket', 'object', 1000, (e, url) => {
             assert.equal(url.length > 0, true)
@@ -163,7 +196,8 @@ describe('Client', function() {
       it('should not generate presigned url with wrong expires param', (done) => {
         try {
           var client = new Minio({
-            endPoint: 'https://localhost:9000',
+            endPoint: 'localhost',
+            port: 9000,
             accessKey: 'accesskey',
             secretKey: 'secretkey',
           })
@@ -174,7 +208,8 @@ describe('Client', function() {
       })
       it('should generate presigned url', (done) => {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
+          port: 9000,
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -188,7 +223,7 @@ describe('Client', function() {
   describe('User Agent', () => {
     it('should have a default user agent', () => {
       var client = new Minio({
-        endPoint: 'https://localhost:9000',
+        endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
@@ -197,7 +232,7 @@ describe('Client', function() {
     })
     it('should set user agent', () => {
       var client = new Minio({
-        endPoint: 'https://localhost:9000',
+        endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
@@ -207,7 +242,7 @@ describe('Client', function() {
     })
     it('should set user agent without comments', () => {
       var client = new Minio({
-        endPoint: 'https://localhost:9000',
+        endPoint: 'localhost',
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
@@ -218,7 +253,7 @@ describe('Client', function() {
     it('should not set user agent without name', (done) => {
       try {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -230,7 +265,7 @@ describe('Client', function() {
     it('should not set user agent with empty name', (done) => {
       try {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -242,7 +277,7 @@ describe('Client', function() {
     it('should not set user agent without version', (done) => {
       try {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -254,7 +289,7 @@ describe('Client', function() {
     it('should not set user agent with empty version', (done) => {
       try {
         var client = new Minio({
-          endPoint: 'https://localhost:9000',
+          endPoint: 'localhost',
           accessKey: 'accesskey',
           secretKey: 'secretkey'
         })
@@ -268,14 +303,16 @@ describe('Client', function() {
     describe('not set', () => {
       var transport = new MockTransport(),
         client = new Minio({
-          endPoint: 'http://localhost:9000'
-        }, transport)
+          endPoint: 'localhost',
+          port: 9000,
+          transport: transport
+        })
       it('should not send auth info without keys', (done) => {
         client.transport.addRequest((params) => {
           assert.deepEqual(params, {
             host: 'localhost',
             port: 9000,
-            protocol: '',
+            protocol: 'https:',
             path: '/bucket/object',
             method: 'HEAD'
           })
@@ -300,24 +337,26 @@ describe('Client', function() {
       it('should not send auth info without keys', (done) => {
         var transport = new MockTransport(),
           client = new Minio({
-            endPoint: 'http://localhost:9000',
+            endPoint: 'localhost',
+            port: 9000,
             accessKey: 'accessKey',
-            secretKey: 'secretKey'
-          }, transport)
+            secretKey: 'secretKey',
+            transport: transport,
+          })
         client.transport.addRequest((params) => {
           assert.equal(true, params.headers.authorization !== null)
           assert.equal(true, params.headers.authorization.indexOf('accessKey') > -1)
           assert.equal(true, params.headers['x-amz-date'] !== null)
-          delete params.headers.authorization
+          delete params.headers['authorization']
           delete params.headers['x-amz-date']
           assert.deepEqual(params, {
             host: 'localhost',
             port: 9000,
-            protocol: '',
+            protocol: 'https:',
             path: '/bucket/object',
             method: 'HEAD',
             headers: {
-              host: 'localhost',
+              host: 'localhost:9000',
               'x-amz-content-sha256': 'e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855'
             }
           })
@@ -344,7 +383,10 @@ describe('Client', function() {
     describe('#makeBucket(bucket, acl, region, callback)', () => {
       it('should call the callback on success', (done) => {
         MockResponse('http://localhost:9000').put('/bucket').reply(200)
-        client.makeBucket('bucket', '', '', done)
+        client.makeBucket('bucket', '', '', (e) => {
+          assert.equal(e, null)
+          done()
+        })
       })
       it('pass an error into the callback on failure', (done) => {
         MockResponse('http://localhost:9000').put('/bucket').reply(400, generateError('code', 'message', 'requestid', 'hostid', '/bucket'))
@@ -540,8 +582,10 @@ describe('Client', function() {
       it('should set acl', (done) => {
         var transport = new MockTransport(),
           client = new Minio({
-            endPoint: 'http://localhost:9000'
-          }, transport)
+            endPoint: 'localhost',
+            port: 9000,
+            transport: transport,
+          })
         client.transport.addRequest((params) => {
           assert.deepEqual(params, {
             host: 'localhost',


### PR DESCRIPTION
Add a new field 'transport' to params and avoid taking new arguments
for Client constructor.