### PR TITLE
getRequestOptions: Constructs now host based on region and bucketName.

### DIFF
--- a/src/main/s3-endpoints.js
+++ b/src/main/s3-endpoints.js
@@ -1,0 +1,35 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+let awsS3Endpoint = {
+  'us-east-1': 's3.amazonaws.com',
+  'us-west-1': 's3-us-west-1.amazonaws.com',
+  'us-west-2': 's3-us-west-2.amazonaws.com',
+  'eu-west-1': 's3-eu-west-1.amazonaws.com',
+  'sa-east-1': 's3-sa-east-1.amazonaws.com',
+  'eu-central-1': 's3-eu-central-1.amazonaws.com',
+  'ap-southeast-1': 's3-ap-southeast-1.amazonaws.com',
+  'ap-southeast-2': 's3-ap-southeast-2.amazonaws.com',
+  'ap-northeast-1': 's3-ap-northeast-1.amazonaws.com',
+}
+
+export function getS3Endpoint(region) {
+  var endpoint = awsS3Endpoint[region]
+  if (endpoint) {
+    return endpoint
+  }
+  return 's3.amazonaws.com'
+}

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -35,7 +35,7 @@ describe('functional tests', function() {
     accessKey: process.env['ACCESS_KEY'],
     secretKey: process.env['SECRET_KEY']
   })
-  var bucketName = 'miniojsbucket'
+  var bucketName = 'miniojs-bucket'
   var objectName = 'miniojsobject'
 
   var _1byte = new Buffer(1)
@@ -95,9 +95,17 @@ describe('functional tests', function() {
   }
 
   describe('makeBucket', () => {
-    // Not testing for non-standard region as DNS propogation takes time.
-    it('should create bucket with acl', done => client.makeBucket(`${bucketName}-acl`, 'public-read', '', done))
+    it('should create bucket with acl', done => client.makeBucket(`${bucketName}-acl`,
+                                                                  'public-read',
+                                                                  'us-west-2', done))
     it('should delete bucket', done => client.removeBucket(`${bucketName}-acl`, done))
+  })
+
+  describe('makeBucket with period', () => {
+    it('should create bucket in eu-central-1 with period', done => client.makeBucket(`${bucketName}.acl.period`,
+                                                                                     'public-read-write',
+                                                                                     'eu-central-1', done))
+    it('should delete bucket', done => client.removeBucket(`${bucketName}.acl.period`, done))
   })
 
   describe('listBuckets', () => {


### PR DESCRIPTION
This patch essentially solves two problems

- accessing bucket names right after they were created. In current style
  if we try to access the buckets we would get 'Access Denied'.
  This can be solved by sending the requests directly to the endpoint
  where the bucket was created. For this we have to automatically use
  the relevant endpoint based on bucket location, similar to how it is
  achieved in 'aws-sdks'.

- bucket names with '.' cannot be used with virtual host style for
  HTTPS requests due to SSL certificate issue, so in this case we fallback
  to using path style instead for such requests, similar to how it is achieved
  in 'aws-sdks'.