### PR TITLE
api: change presignedPostPolicy to return back proper URL.

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,11 +118,11 @@ s3client.listBuckets(function(e, bucketStream) {
 
 ### Presigned
 
-[presignedGetObject(bucket, object, expires) : String](examples/presigned-getobject.js)
+[presignedGetObject(bucket, object, expires, cb)](examples/presigned-getobject.js)
 
-[presignedPutObject(bucket, object, expires) : String](examples/presigned-putobject.js)
+[presignedPutObject(bucket, object, expires, cb](examples/presigned-putobject.js)
 
-[presignedPostPolicy(postPolicy) : Object](examples/presigned-postpolicy.js)
+[presignedPostPolicy(postPolicy, cb)](examples/presigned-postpolicy.js)
 
 ## Contribute
 

--- a/examples/presigned-postpolicy.js
+++ b/examples/presigned-postpolicy.js
@@ -39,10 +39,10 @@ policy.setExpires(expires)
 
 policy.setContentLengthRange(1024, 1024*1024) // Min upload length is 1KB Max upload size is 1MB
 
-s3Client.presignedPostPolicy(policy, function(e, formData) {
+s3Client.presignedPostPolicy(policy, function(e, urlStr, formData) {
   if (e) return console.log(e)
   var curl = []
-  curl.push('curl https://s3.amazonaws.com/my-bucketname')
+  curl.push(`curl ${urlStr}`)
   for (var key in formData) {
     if (formData.hasOwnProperty(key)) {
       var value = formData[key]

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -336,9 +336,9 @@ export default class Client {
     }
 
     var _makeRequest = (e, region) => {
+      if (e) return cb(e)
       options.region = region
       var reqOptions = this.getRequestOptions(options)
-      if (e) return cb(e)
       if (!this.anonymous) {
         reqOptions.headers['x-amz-date'] = Moment().utc().format('YYYYMMDDTHHmmss') + 'Z'
         reqOptions.headers['x-amz-content-sha256'] = sha256sum
@@ -1389,7 +1389,12 @@ export default class Client {
       var signature = postPresignSignatureV4(region, date, this.secretKey, policyBase64)
 
       postPolicy.formData['x-amz-signature'] = signature
-      cb(null, postPolicy.formData)
+      var opts = {}
+      opts.region = region
+      opts.bucketName = postPolicy.formData.bucket
+      var reqOptions = this.getRequestOptions(opts)
+      var urlStr = reqOptions.protocol + '//' + reqOptions.host + reqOptions.path
+      cb(null, urlStr, postPolicy.formData)
     })
   }
 

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -122,7 +122,7 @@ describe('functional tests', function() {
     it('should check if bucket exists', done => client.bucketExists(bucketName, done))
     it('should check if bucket does not exist', done => {
       client.bucketExists(bucketName+'random', (e) => {
-        if (e.name === 'NoSuchBucket') return done()
+        if (e.code === 'NoSuchBucket') return done()
         done(new Error())
       })
     })
@@ -445,9 +445,9 @@ describe('functional tests', function() {
       expires.setSeconds(24 * 60 * 60 * 10)
       policy.setExpires(expires)
 
-      client.presignedPostPolicy(policy, (e, formData) => {
+      client.presignedPostPolicy(policy, (e, urlStr, formData) => {
         if (e) return done(e)
-        var req = superagent.post(`https://${bucketName}.s3.amazonaws.com`)
+        var req = superagent.post(`${urlStr}`)
         _.each(formData, (value, key) => req.field(key, value))
         req.field('file', _1byte)
         req.end(function(e, response) {


### PR DESCRIPTION
The reason to do this is because bucket names can be in
various different regions and for users it becomes convenient
if we return back the proper endpoint which can be safely used
without worrying about virtual host style or path style.

We have enough information to provide a proper URL, this is also
consistent with other Presigned operations as it would be an
expected behavior.