### PR TITLE
* Fixed error on downloading non-existing resourse

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -672,11 +672,8 @@ export default class Client {
 
     // Rename wrapper.
     var rename = () => {
-      if (partFile) {
-        fs.rename(partFile, filePath, cb)
-      } else {
-        cb(new Error('Object not downloaded'))
-      }
+      if (err) return cb(err)
+      fs.rename(partFile, filePath, cb)
     }
 
     async.waterfall([

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -672,7 +672,11 @@ export default class Client {
 
     // Rename wrapper.
     var rename = () => {
-      fs.rename(partFile, filePath, cb)
+      if (partFile) {
+        fs.rename(partFile, filePath, cb)
+      } else {
+        cb(new Error('Object not downloaded'))
+      }
     }
 
     async.waterfall([

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -671,7 +671,7 @@ export default class Client {
     var objStat
 
     // Rename wrapper.
-    var rename = () => {
+    var rename = err => {
       if (err) return cb(err)
       fs.rename(partFile, filePath, cb)
     }


### PR DESCRIPTION
Previously when you try to `fGetObject` which does not exist on the server  the app crashed with:

```
TypeError: old path must be a string at TypeError (native)
    at Object.fs.rename (fs.js:673:11)
    at rename (/source/minio.js:675:10)
```

This was caused by the fact that the `partFile` stays `null` if the download fails, then `fs` fails to rename the file.