### PR TITLE
Use encodeURIComponent directly and remove unneeded code.

### DIFF
--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -18,25 +18,11 @@ import stream from 'stream'
 import _ from 'lodash'
 
 export function uriEscape(string) {
-  var output = string
-    // this was originally escape instead of encodeURIComponent but escape is deprecated.
-  output = output.replace(/[^A-Za-z0-9_.~\-%]+/g, encodeURIComponent)
-
-  // AWS percent-encodes some extra non-standard characters in a URI
-  output = output.replace(/[*]/g, function(ch) {
-    return '%' + ch.charCodeAt(0).toString(16).toUpperCase()
-  })
-
-  return output
+  return encodeURIComponent(string)
 }
 
 export function uriResourceEscape(string) {
-  var output = string
-    // this was originally escape instead of encodeURIComponent but escape is deprecated.
-  output = output.replace(/[^A-Za-z0-9_.~\-%]+/g, encodeURIComponent)
-  output = output.replace(/%2F/g, '/')
-
-  return output
+  return encodeURIComponent(string).replace(/%2F/g, '/')
 }
 
 export function getScope(region, date) {

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -18,11 +18,13 @@ import stream from 'stream'
 import _ from 'lodash'
 
 export function uriEscape(string) {
-  return encodeURIComponent(string)
+  return encodeURIComponent(string).replace(/[*]/g, function(ch) {
+    return '%' + ch.charCodeAt(0).toString(16).toUpperCase();
+  })
 }
 
 export function uriResourceEscape(string) {
-  return encodeURIComponent(string).replace(/%2F/g, '/')
+  return uriEscape(string).replace(/%2F/g, '/')
 }
 
 export function getScope(region, date) {


### PR DESCRIPTION
@harshavardhana see if this is ok:

```
-  // AWS percent-encodes some extra non-standard characters in a URI
-  output = output.replace(/[*]/g, function(ch) {
-    return '%' + ch.charCodeAt(0).toString(16).toUpperCase()
-  
})
```

i could not find this in minio-go so removed it.