### PR TITLE
make `presignedPutObject` expiry actually optional

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1208,10 +1208,14 @@ export default class Client {
   // __Arguments__
   // * `bucketName` _string_: name of the bucket
   // * `objectName` _string_: name of the object
-  // * `expiry` _number_: expiry in seconds
+  // * `expiry` _number_: expiry in seconds (optional, default 7 days)
   presignedPutObject(bucketName, objectName, expires, cb) {
     if (this.anonymous) {
       throw new errors.AnonymousRequestError('Presigned PUT url cannot be generated for anonymous requests')
+    }
+    if (isFunction(expires)) {
+      cb = expires
+      expires = 24 * 60 * 60 * 7
     }
     if (!isValidBucketName(bucketName)) {
       throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -195,6 +195,13 @@ describe('Client', function() {
           done()
         })
       })
+      it('should use default expiry if none is given', (done) => {
+        client.presignedPutObject('bucket', 'object', (e, url) => {
+          assert.equal(e, null)
+          assert(url.length > 0)
+          done()
+        })
+      })
     })
   })
   describe('User Agent', () => {


### PR DESCRIPTION
Previous to this commit, `presignedPutObject` would actually throw a
TypeError if you don't put in an expiry, unlike `presignedGetObject`.
However, the documentation on the expiry stated that it is optional and
defaults to 7 days. This fixes that and adds a test.