### PR TITLE
add `getBucketPolicy` and `setBucketPolicy`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -32,13 +32,13 @@ var s3Client = new Minio({
 
 ```
 
-| Bucket operations       | Object operations      | Presigned operations | Notification config. operations |
+| Bucket operations       | Object operations      | Presigned operations | Bucket Policy & Notification operations |
 | ------------- |-------------| -----| ----- |
 | [`makeBucket`](#makeBucket)    | [`getObject`](#getObject) | [`presignedGetObject`](#presignedGetObject) | [`getBucketNotification`](#getBucketNotification) |
 | [`listBuckets`](#listBuckets)  | [`getPartialObject`](#getPartialObject)    |   [`presignedPutObject`](#presignedPutObject) | [`setBucketNotification`](#setBucketNotification) |
 | [`bucketExists`](#bucketExists) | [`fGetObject`](#fGetObject)    |    [`presignedPostPolicy`](#presignedPostPolicy) | [`deleteBucketNotification`](#deleteBucketNotification) |
-| [`removeBucket`](#removeBucket)      | [`putObject`](#putObject)       |
-| [`listObjects`](#listObjects) | [`fPutObject`](#fPutObject)   |
+| [`removeBucket`](#removeBucket)      | [`putObject`](#putObject)       |     | [`getBucketPolicy`](#getBucketPolicy)
+| [`listObjects`](#listObjects) | [`fPutObject`](#fPutObject)   |   |   [`setBucketPolicy`](#setBucketPolicy)
 | [`listIncompleteUploads`](#listIncompleteUploads) |[`statObject`](#statObject) |
 |     |  [`removeObject`](#removeObject)    |
 |  | [`removeIncompleteUpload`](#removeIncompleteUpload)  |
@@ -768,7 +768,7 @@ minioClient.presignedPostPolicy(policy, function(err, postURL, formData) {
 
 ```
 
-## 5. Notification config operations
+## 5. Bucket Policy & Notification operations
 
 Buckets are configured to trigger notifications on specified types of events and paths filters.
 
@@ -860,6 +860,61 @@ minioClient.deleteBucketNotification('my-bucketname', function(e) {
     return console.log(e)
   }
   console.log("True")
+})
+```
+
+<a name="getBucketPolicy"></a>
+### getBucketPolicy(bucketName, objectPrefix, callback)
+
+Get the bucket policy associated with the specified bucket. If `objectPrefix`
+is not empty, the bucket policy will be filtered based on object permissions
+as well.
+
+__Parameters__
+
+
+| Param  |  Type | Description  |
+|---|---|---|
+| `bucketName`  | _string_  | Name of the bucket |
+| `objectPrefix` | _string_ | Prefix of objects in the bucket with which to filter permissions off of. Use `''` for entire bucket. |
+| `callback(err, policy)`  | _function_  | Callback function is called with non `null` err value in case of error. `policy` will be the string representation of the bucket policy (`minio.Policy.NONE`, `minio.Policy.READONLY`, `minio.Policy.WRITEONLY`, or `minio.Policy.READWRITE`). |
+
+
+```js
+// Retrieve bucket policy of 'my-bucketname' that applies to all objects that
+// start with 'img-'.
+minioClient.getBucketPolicy('my-bucketname', 'img-', function(err, policy) {
+  if (err) throw err
+
+  console.log(`Bucket policy: ${policy}`)
+})
+```
+
+<a name="setBucketPolicy"></a>
+### setBucketPolicy(bucketName, objectPrefix, bucketPolicy, callback)
+
+Set the bucket policy associated with the specified bucket. If `objectPrefix`
+is not empty, the bucket policy will only be assigned to objects that fit the
+given prefix.
+
+__Parameters__
+
+
+| Param  |  Type | Description  |
+|---|---|---|
+| `bucketName`  | _string_  | Name of the bucket |
+| `objectPrefix` | _string_ | Prefix of objects in the bucket to modify permissions of. Use `''` for entire bucket. |
+| `bucketPolicy` | _string_ | The bucket policy. This can be: `minio.Policy.NONE`, `minio.Policy.READONLY`, `minio.Policy.WRITEONLY`, or `minio.Policy.READWRITE`. |
+| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. |
+
+
+```js
+// Set the bucket policy of `my-bucketname` to `readonly` (only allow retrieval),
+// but only for objects that start with 'img-'.
+minioClient.setBucketPolicy('my-bucketname', 'img-', minio.Policy.READONLY, function(err) {
+  if (err) throw err
+
+  console.log('Set bucket policy to \'readonly\'.')
 })
 ```
 

--- a/examples/get-bucket-policy.js
+++ b/examples/get-bucket-policy.js
@@ -1,0 +1,35 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname
+// are dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+// Retrieves the bucket policy and logs it to the console.
+// The second argument is the prefix for objects, leave empty if you don't
+// want to filter based on object-specific permissions.
+s3Client.getBucketPolicy('my-bucketname', '', (err, policy) => {
+	if (err) throw err
+
+	console.log(`Bucket policy: ${policy}`)
+})

--- a/examples/set-bucket-policy.js
+++ b/examples/set-bucket-policy.js
@@ -1,0 +1,37 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, and my-bucketname
+// are dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+// Sets the bucket policy to 'readonly'. This means that objects can only be
+// retrieved rather than created, modified, or destroyed in this bucket.
+
+// The second parameter is for filtering based on objects — you can leave this
+// empty if you'd like the permissions to apply to the entire bucket.
+s3Client.setBucketPolicy('my-bucketname', '', Minio.Policy.READONLY, (err) => {
+	if (err) throw err
+
+	console.log('Set bucket policy to \'readonly\'.')
+})

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "block-stream2": "^1.0.0",
     "concat-stream": "^1.4.8",
     "es6-error": "^2.0.2",
-    "lodash": "^3.10.1",
+    "lodash": "^4.14.2",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.3",
     "source-map-support": "^0.2.10",

--- a/src/main/bucket-policy.js
+++ b/src/main/bucket-policy.js
@@ -1,0 +1,211 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import _ from 'lodash'
+import * as errors from './errors';
+import { isValidBucketName } from './helpers'
+
+export const Policy = {
+  NONE: 'none',
+  READONLY: 'readonly',
+  WRITEONLY: 'writeonly',
+  READWRITE: 'readwrite'
+}
+
+const resourcePrefix = 'arn:aws:s3:::'
+
+const readActions = {
+  bucket: [ 's3:GetBucketLocation' ],
+  object: [ 's3:GetObject' ]
+}
+
+const writeActions = {
+  bucket: [ 's3:GetBucketLocation', 's3:ListBucketMultipartUploads' ],
+  object: [ 's3:AbortMultipartUpload', 's3:DeleteObject',
+            's3:ListMultipartUploadParts', 's3:PutObject' ]
+}
+
+// Returns the string version of the bucket policy.
+export function parseBucketPolicy(policy, bucketName, objectPrefix) {
+  let statements = policy.Statement
+
+  // If there are no statements, it's none.
+  if (statements.length === 0) return Policy.NONE
+
+  let bucketResource = `${resourcePrefix}${bucketName}`
+  let objectResource = `${resourcePrefix}${bucketName}/${objectPrefix}`
+
+  let actions = {
+    bucket: [],
+    object: []
+  }
+
+  // Loop through the statements and aggregate actions which are allowed.
+  for (let i = 0; i < statements.length; i++) {
+    let statement = statements[i]
+
+    // Normalize the statement, as AWS will drop arrays with length 1.
+    statement = normalizeStatement(statement)
+
+    // Verify the statement before we union-ize the actions.
+    if (!_.some(statement.Principal.AWS, value => value == '*')) continue
+    if (statement.Effect != 'Allow') continue
+
+    // Check for object actions or bucket actions, depending on the resource.
+    if (pertainsTo(statement, objectResource)) {
+      actions.object = _.union(actions.object, statement.Action)
+    } else if (pertainsTo(statement, bucketResource)) {
+      actions.bucket = _.union(actions.bucket, statement.Action)
+    }
+  }
+
+  // Check for permissions.
+  let canRead = false
+  let canWrite = false
+
+  // If it has a subarray inside, there are full permissions to either
+  // read, write, or both.
+  if (isSubArrayOf(actions.bucket, writeActions.bucket) &&
+      isSubArrayOf(actions.object, writeActions.object)) {
+    canWrite = true
+  }
+
+  if (isSubArrayOf(actions.bucket, readActions.bucket) &&
+      isSubArrayOf(actions.object, readActions.object)) {
+    canRead = true
+  }
+
+  if (canRead && canWrite) return Policy.READWRITE
+  else if (canRead) return Policy.READONLY
+  else if (canWrite) return Policy.WRITEONLY
+  else return Policy.NONE
+}
+
+// Generate a statement payload to submit to S3 based on the given policy.
+export function generateBucketPolicy(policy, bucketName, objectPrefix) {
+  if (!isValidBucketName(bucketName)) {
+    throw new errors.InvalidBucketNameError(`Invalid bucket name: ${bucketName}`)
+  }
+  if (!isValidBucketPolicy(policy)) {
+      throw new errors.InvalidBucketPolicyError(`Invalid bucket policy: ${bucketPolicy}` +
+                                                `(must be 'none', 'readonly', 'writeonly', or 'readwrite')`)
+  }
+
+  // Merge the actions together based on the given policy.
+  let actions = {
+    bucket: [],
+    object: []
+  }
+
+  if (policy == Policy.READONLY || policy == Policy.READWRITE) {
+    // Do read statements.
+    actions.bucket = _.concat(actions.bucket, readActions.bucket)
+    actions.object = _.concat(actions.object, readActions.object)
+  }
+
+  if (policy == Policy.WRITEONLY || policy == Policy.READWRITE) {
+    // Do write statements.
+    actions.bucket = _.concat(actions.bucket, writeActions.bucket)
+    actions.object = _.concat(actions.object, writeActions.object)
+  }
+
+  // Drop any duplicated actions.
+  actions.bucket = _.uniq(actions.bucket)
+  actions.object = _.uniq(actions.object)
+
+  // Form statements from the actions. We'll create three statements:
+  // one for basic bucket permissions, one for basic object permissions,
+  // and finally a special statement for ListBucket, which should be
+  // handled separately.
+  let statements = []
+
+  if (actions.bucket.length > 0) {
+    statements.push(createStatement(actions.bucket, `${resourcePrefix}${bucketName}`))
+  }
+
+  if (actions.object.length > 0) {
+    statements.push(createStatement(actions.object, `${resourcePrefix}${bucketName}/${objectPrefix}*`))
+  }
+
+  // If reading permission is on, add ListBucket.
+  if (policy == Policy.READONLY || policy == Policy.READWRITE) {
+    let listBucketStatement = createStatement([ 's3:ListBucket' ], `${resourcePrefix}${bucketName}`)
+
+    // It has a condition on it if there is a prefix, thus we do it separately.
+    if (objectPrefix !== '') {
+      listBucketStatement.Condition = { StringEquals: { 's3:prefix': objectPrefix } }
+    }
+
+    statements.push(listBucketStatement)
+  }
+
+  // s3 requires a wrapper around the statements.
+  return {
+    'Version': '2012-10-17',
+    'Statement': statements
+  }
+}
+
+export function isValidBucketPolicy(policy) {
+  return policy == Policy.NONE ||
+         policy == Policy.READONLY ||
+         policy == Policy.WRITEONLY ||
+         policy == Policy.READWRITE
+}
+
+// Checks to see if the parent array has all the values in the child array.
+// Take the intersection for both. If the lengths are the same, the contents
+// of the child are inside the parent.
+function isSubArrayOf(parent, child) {
+  return (_.intersection(parent, child)).length == child.length
+}
+
+// Checks if the statement pertains to the given resource. Returns a boolean.
+function pertainsTo(statement, resource) {
+  let resources = statement.Resource
+
+  for (let i = 0; i < resources.length; i++) {
+    if (_.startsWith(resources[i], resource)) return true
+  }
+
+  return false
+}
+
+// Create an s3 Allow Statement.
+function createStatement(action, resource) {
+  return {
+    Sid: '',
+    Effect: 'Allow',
+    Principal: { 'AWS': ['*'] },
+    Action: action,
+    Resource: [ resource ]
+  }
+}
+
+// AWS will sometimes drop arrays of length 1 for their values, so normalize
+// these back to arrays with length 1.
+function normalizeStatement(statement) {
+  if (typeof statement.Principal.AWS === 'string')
+    statement.Principal.AWS = [ statement.Principal.AWS ]
+
+  if (typeof statement.Action === 'string')
+    statement.Action = [ statement.Action ]
+
+  if (typeof statement.Resource === 'string')
+    statement.Resource = [ statement.Resource ]
+
+  return statement
+}

--- a/src/main/errors.js
+++ b/src/main/errors.js
@@ -104,6 +104,13 @@ export class InvalidPrefixError extends ExtendableError {
   }
 }
 
+// InvalidBucketPolicyError generated when the given bucket policy is invalid.
+export class InvalidBucketPolicyError extends ExtendableError {
+  constructor(message) {
+    super(message)
+  }
+}
+
 // IncorrectSizeError generated when total data read mismatches with
 // the input size.
 export class IncorrectSizeError extends ExtendableError {

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -15,6 +15,7 @@
  */
 
 import * as xmlParsers from './xml-parsers.js'
+import { parseBucketPolicy } from './bucket-policy.js'
 import * as _ from 'lodash'
 import Through2 from 'through2'
 import Crypto from 'crypto';
@@ -198,4 +199,9 @@ export function getBucketRegionTransformer() {
 // Parses GET/SET BucketNotification response
 export function getBucketNotificationTransformer() {
   return getConcater(xmlParsers.parseBucketNotification)
+}
+
+// Parses GET BucketPolicy response.
+export function getBucketPolicyTransformer() {
+  return getConcater(response => JSON.parse(response))
 }


### PR DESCRIPTION
This commit adds two new functions, `getBucketPolicy` and
`setBucketPolicy`, both of which allow the user to manage bucket policy
via the node client. Documentation, examples, tests are included.