### PR TITLE
ci: run unit tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ node_js:
 script:
 - gulp browserify
 - gulp lint
+- npm test
 
 notifications:
   slack:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,6 +13,7 @@ build_script:
   - npm install -g gulp
   - gulp browserify
   - gulp lint
+  - npm test
 
 # to disable automatic tests
 test: off


### PR DESCRIPTION
Before this, for reasons unknown, the CIs wouldn't run the unit tests,
they would only run the linters. To make life easier on the maintainers,
run the unit tests for each PR.