### PR TITLE
add new stream uploader

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -492,7 +492,7 @@ __Parameters__
 | `bucketName`  |_string_   | Name of the bucket.  |
 | `objectName`  |_string_   | Name of the object.  |
 | `stream`  | _Stream_  |Readable stream.   |
-|`size`   | _number_  | Size of the object.  |
+|`size`   | _number_  | Size of the object (optional).  |
 |`contentType`   | _string_  | Content-Type of the object (optional, default `application/octet-stream`).  |
 | `callback(err, etag)` | _function_ | Non-null `err` indicates error, `etag` _string_ is the etag of the object uploaded.|
 
@@ -510,7 +510,7 @@ var fileStat = Fs.stat(file, function(err, stats) {
   if (err) {
     return console.log(err)
   }
-  minioClient.putObject('mybucket', '40mbfile', fileStream, stats.size, 'application/octet-stream', function(err, etag) {
+  minioClient.putObject('mybucket', '40mbfile', fileStream, stats.size, function(err, etag) {
     return console.log(err, etag) // err should be null
   })
 })
@@ -537,7 +537,7 @@ __Example__
 ```js
 
 var buffer = 'Hello World'
-minioClient.putObject('mybucket', 'hello-file', buffer, 'application/octet-stream', function(err, etag) {
+minioClient.putObject('mybucket', 'hello-file', buffer, function(err, etag) {
   return console.log(err, etag) // err should be null
 })
 

--- a/src/main/object-uploader.js
+++ b/src/main/object-uploader.js
@@ -1,0 +1,224 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Transform } from 'stream'
+import { Hash } from 'crypto'
+import * as querystring from 'querystring'
+
+// We extend Transform because Writable does not implement ._flush().
+export default class ObjectUploader extends Transform {
+
+  constructor(client, bucketName, objectName, partSize, callback) {
+    super()
+
+    this.client = client
+    this.bucketName = bucketName
+    this.objectName = objectName
+    // The size of each multipart, chunked by BlockStream2.
+    this.partSize = partSize
+    // Call like: callback(error, etag).
+    this.callback = callback
+
+    // We need to keep track of what number chunk/part we're on. This increments
+    // each time _write() is called. Starts with 1, not 0.
+    this.partNumber = 1
+
+    // A list of the previously uploaded chunks, for resuming a file upload. This
+    // will be null if we aren't resuming an upload.
+    this.oldParts = null
+
+    // Keep track of the etags for aggregating the chunks together later. Each
+    // etag represents a single chunk of the file.
+    this.etags = []
+
+    // Don't bother with the content-type, default to octet stream for simplicity.
+    this.contentType = 'application/octet-stream'
+
+    // This is for the multipart upload request — if null, we're either not initiated
+    // yet or we're flushing in one packet.
+    this.id = null
+
+    // Handle errors.
+    this.on('error', err => {
+      callback(err)
+    })
+  }
+
+  _transform(chunk, encoding, callback) {
+    // Calculate the md5 sum.
+    let md5 = new Hash('md5')
+    md5.update(chunk)
+    let md5sum = md5.digest()
+
+    let method = 'PUT'
+    let headers = {
+      'Content-Length': chunk.length,
+      'Content-Type': this.contentType,
+      'Content-MD5': md5sum.toString('base64')
+    }
+
+    // We can flush the object in one packet if it fits in one chunk. This is true
+    // if the chunk size is smaller than the part size, signifying the end of the
+    // stream.
+    if (this.partNumber == 1 && chunk.length < this.partSize) {
+      // PUT the chunk in a single request — use an empty query.
+      let options = {
+        method, headers,
+        query: '',
+        bucketName: this.bucketName,
+        objectName: this.objectName
+      }
+
+      this.client.makeRequest(options, chunk, 200, '', (err, response) => {
+        if (err) return callback(err)
+
+        let etag = response.headers.etag
+        if (etag) {
+          etag = etag.replace(/^\"/, '').replace(/\"$/, '')
+        }
+
+        // Ignore the 'data' event so that the stream closes. (nodejs stream requirement)
+        response.on('data', () => {})
+
+        // Give the etag back, we're done!
+        process.nextTick(() => {
+          this.callback(null, etag)
+        })
+
+        // Because we're sure the stream has ended, allow it to flush and end.
+        callback()
+      })
+
+      return
+    }
+
+    // If we aren't flushing in one packet, we need to initiate the multipart upload,
+    // if it hasn't already been done. The write will be buffered until the upload has been
+    // initiated.
+    if (this.id === null) {
+      this.once('ready', () => {
+        this._transform(chunk, encoding, callback)
+      })
+
+      // Check for an incomplete previous upload.
+      this.client.findUploadId(this.bucketName, this.objectName, (err, id) => {
+        if (err) return this.emit('error', err)
+
+        // If no upload ID exists, initiate a new one.
+        if (!id) {
+          this.client.initiateNewMultipartUpload(this.bucketName, this.objectName, this.contentType, (err, id) => {
+            if (err) return callback(err)
+
+            this.id = id
+
+            // We are now ready to accept new chunks — this will flush the buffered chunk.
+            this.emit('ready')
+          })
+
+          return
+        }
+
+        this.id = id
+
+        // Retrieve the pre-uploaded parts, if we need to resume the upload.
+        this.client.listParts(this.bucketName, this.objectName, id, (err, etags) => {
+          if (err) return this.emit('error', err)
+
+          // It is possible for no parts to be already uploaded.
+          if (!etags) etags = []
+
+          // oldParts will become an object, allowing oldParts[partNumber].etag
+          this.oldParts = etags.reduce(function(prev, item) {
+            if (!prev[item.part]) {
+              prev[item.part] = item
+            }
+            return prev
+          }, {})
+
+          this.emit('ready')
+        })
+      })
+
+      return
+    }
+
+    // Continue uploading various parts if we have initiated multipart upload.
+    let partNumber = this.partNumber++
+
+    // Check to see if we've already uploaded this chunk. If the hash sums match,
+    // we can skip to the next chunk.
+    if (this.oldParts) {
+      let oldPart = this.oldParts[partNumber]
+
+      if (oldPart && md5sum.toString('hex') === oldPart.etag) {
+        // The md5 matches, the chunk has already been uploaded.
+        this.etags.push({part: partNumber, etag: oldPart.etag})
+
+        callback()
+        return
+      }
+    }
+
+    // Write the chunk with an uploader.
+    let query = querystring.stringify({
+      partNumber: partNumber,
+      uploadId: this.id
+    })
+
+    let options = {
+      method, query, headers,
+      bucketName: this.bucketName,
+      objectName: this.objectName
+    }
+
+    this.client.makeRequest(options, chunk, 200, '', (err, response) => {
+      if (err) return callback(err)
+
+      // In order to aggregate the parts together, we need to collect the etags.
+      let etag = response.headers.etag
+      if (etag)
+        etag = etag.replace(/^\"/, '').replace(/\"$/, '')
+
+      this.etags.push({part: partNumber, etag})
+
+      // We're ready for the next chunk.
+      callback()
+    })
+  }
+
+  _flush(callback) {
+    // If it has been uploaded in a single packet, we don't have to do anything.
+    if (this.id === null) {
+      return
+    }
+
+    // This is called when all of the chunks uploaded successfully, thus
+    // completing the multipart upload.
+    this.client.completeMultipartUpload(this.bucketName, this.objectName, this.id,
+                                        this.etags, (err, etag) => {
+      if (err) return callback(err)
+
+      // Call our callback on the next tick to allow the streams infrastructure
+      // to finish what its doing before we continue.
+      process.nextTick(() => {
+        this.callback(null, etag)
+      })
+
+      callback()
+    })
+  }
+
+}

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -114,31 +114,6 @@ export function getErrorTransformer(response) {
   }, true)
 }
 
-// Makes sure that only size number of bytes go through this stream
-export function getSizeLimiter(size, stream, chunker) {
-  var sizeRemaining = size
-  return Through2.obj(function(chunk, enc, cb) {
-    var length = Math.min(chunk.length, sizeRemaining)
-    // We should read only till 'size'
-    if (length < chunk.length) chunk = chunk.slice(0, length)
-    this.push(chunk)
-    sizeRemaining -= length
-    if (sizeRemaining === 0) {
-      // Unpipe so that the streams do not send us more data
-      stream.unpipe()
-      chunker.unpipe()
-      this.push(null)
-    }
-    cb()
-  }, function(cb) {
-    if (sizeRemaining !== 0) {
-      return cb(new errors.IncorrectSizeError(`size of the input stream is not equal to the expected size(${size})`))
-    }
-    this.push(null)
-    cb()
-  })
-}
-
 // A through stream that calculates md5sum and sha256sum
 export function getHashSummer(enableSHA256) {
   var md5 = Crypto.createHash('md5')

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -231,11 +231,7 @@ describe('functional tests', function() {
 
   describe('listIncompleteUploads removeIncompleteUpload', () => {
     it('should create multipart request', done => {
-      var stream = readableStream('')
-      client.putObject(bucketName, _11mbObjectName, stream, _11mb.length, '', (e) => {
-        if(!e) return done(new Error('Expecing error'))
-        done()
-      })
+      client.initiateNewMultipartUpload(bucketName, _11mbObjectName, 'application/octet-stream', done)
     })
     it('should list incomplete upload', done => {
       var found = false
@@ -275,70 +271,6 @@ describe('functional tests', function() {
       fs.unlinkSync(tmpFileDownload)
       client.removeObject(bucketName, _11mbObjectName, done)
     })
-  })
-
-  describe('putObject (resume)', () => {
-    it('should create an incomplete upload', done => {
-      var stream = readableStream(_10mb)
-      // write just 10mb, so that it errors out and incomplete upload is created
-      client.putObject(bucketName, _11mbObjectName, stream, _11mb.length, '', (e, etag) => {
-        if (!e) done(new Error('Expecting Error'))
-        done()
-      })
-    })
-    it('should confirm the presence of incomplete upload', done => {
-      var stream = client.listIncompleteUploads(bucketName, _11mbObjectName, true)
-      var result
-      stream.on('error', done)
-      stream.on('data', data => {
-        if (data.key === _11mbObjectName)
-          result = data
-      })
-      stream.on('end', () => {
-        if (result) {
-          return done()
-        }
-        done(new Error('Uploaded part not found'))
-      })
-    })
-    it('should resume upload', done => {
-      var stream = readableStream(_11mb)
-      client.putObject(bucketName, _11mbObjectName, stream, _11mb.length, '', (e, etag) => {
-        if (e) return done(e)
-        done()
-      })
-    })
-    it('should remove the uploaded object', done => client.removeObject(bucketName, _11mbObjectName, done))
-  })
-
-  describe('fPutObject-resume', () => {
-    var _11mbTmpFile = `${tmpDir}/${_11mbObjectName}`
-    it('should create tmp file', () => fs.writeFileSync(_11mbTmpFile, _11mb))
-    it('should create an incomplete upload', done => {
-      var stream = readableStream(_10mb)
-      // write just 10mb, so that it errors out and incomplete upload is created
-      client.putObject(bucketName, _11mbObjectName, stream, _11mb.length, '', (e, etag) => {
-        if (!e) done(new Error('Expecting Error'))
-        done()
-      })
-    })
-    it('should confirm the presence of incomplete upload', done => {
-      var stream = client.listIncompleteUploads(bucketName, _11mbObjectName, true)
-      var result
-      stream.on('error', done)
-      stream.on('data', data => {
-        if (data.key === _11mbObjectName)
-          result = data
-      })
-      stream.on('end', () => {
-        if (result) {
-          return done()
-        }
-        done(new Error('Uploaded part not found'))
-      })
-    })
-    it('should resume upload', done => client.fPutObject(bucketName, _11mbObjectName, _11mbTmpFile, '', done))
-    it('should remove the uploaded object', done => client.removeObject(bucketName, _11mbObjectName, done))
   })
 
   describe('fGetObject-resume', () => {

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -727,6 +727,30 @@ describe('Client', function() {
             }
           })
         })
+        it('should fail with invalid bucket name', () => {
+          assert.throws(() => {
+            client.putObject('ab', 'object', () => {})
+          }, /Invalid bucket name/)
+        })
+        it('should fail with invalid object name', () => {
+          assert.throws(() => {
+            client.putObject('bucket', '', () => {})
+          }, /Invalid object name/)
+        })
+        it('should fail without callback', () => {
+          // Whether or not size is there.
+          assert.throws(() => {
+            client.putObject('bucket', 'object', 'slugz', 5)
+          }, /callback should be of type "function"/)
+          assert.throws(() => {
+            client.putObject('bucket', 'object', new Buffer('slug'))
+          }, /callback should be of type "function"/)
+        })
+        it('should error with size > maxObjectSize', () => {
+          assert.throws(() => {
+            client.putObject('bucket', 'object', new Stream.Readable(), client.maxObjectSize + 1, () => {})
+          }, /size should not be more than/)
+        })
         it('should fail on null bucket', (done) => {
           try {
             client.putObject(null, 'hello', null, 1, '')
@@ -849,7 +873,7 @@ describe('Client', function() {
           s.push(null)
           client.putObject('bucket', 'object', s, 11 * 1024 * 1024, '', done)
         })
-        it('should fail if actual size is smaller than expected', (done) => {
+        it('should succeed if actual size is smaller than expected', (done) => {
           MockResponse('http://localhost:9000').get('/bucket?uploads&max-uploads=1000&prefix=object').reply(200, '<ListMultipartUploadsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Bucket>golang</Bucket><KeyMarker></KeyMarker><UploadIdMarker></UploadIdMarker><NextKeyMarker></NextKeyMarker><NextUploadIdMarker></NextUploadIdMarker><EncodingType></EncodingType><MaxUploads>1000</MaxUploads><IsTruncated>false</IsTruncated><Prefix></Prefix><Delimiter></Delimiter></ListMultipartUploadsResult>')
           MockResponse('http://localhost:9000').post('/bucket/object?uploads').reply(200, '<?xml version="1.0" encoding="UTF-8"?>\n<InitiateMultipartUploadResult><Bucket>bucket</Bucket><Key>object</Key><UploadId>uploadid</UploadId></InitiateMultipartUploadResult>')
           MockResponse('http://localhost:9000').put('/bucket/object?partNumber=1&uploadId=uploadid', (body) => {
@@ -859,20 +883,22 @@ describe('Client', function() {
           })
           MockResponse('http://localhost:9000').put('/bucket/object?partNumber=2&uploadId=uploadid', (body) => {
             return body.length === 5 * 1024 * 1024
-
           }).reply(200, '', {
             etag: 'etag2'
           })
+          MockResponse('http://localhost:9000').put('/bucket/object?partNumber=3&uploadId=uploadid', (body) => {
+            return body.length === 1 * 1024 * 1024
+          }).reply(200, '', {
+            etag: 'etag3'
+          })
+          MockResponse('http://localhost:9000').post('/bucket/object?uploadId=uploadid').reply(200, '<?xml version="1.0" encoding="UTF-8"?><CompleteMultipartUploadResult><Bucket>bucket</Bucket><Key>object</Key><Location>location</Location><ETag>"3858f62230ac3c915f300c664312c11f"</ETag></CompleteMultipartUploadResult>')
           var s = new Stream.Readable()
           s._read = function() {}
           for (var i = 0; i < 11 * 1024; i++) {
             s.push(uploadData)
           }
           s.push(null)
-          client.putObject('bucket', 'object', s, 12 * 1024 * 1024, '', (e) => {
-            assert.equal(e.name, 'IncorrectSizeError')
-            done()
-          })
+          client.putObject('bucket', 'object', s, 12 * 1024 * 1024, '', done)
         })
         it('should succeed if actual size is larger than expected', (done) => {
           MockResponse('http://localhost:9000').get('/bucket?uploads&max-uploads=1000&prefix=object').reply(200, '<ListMultipartUploadsResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Bucket>golang</Bucket><KeyMarker></KeyMarker><UploadIdMarker></UploadIdMarker><NextKeyMarker></NextKeyMarker><NextUploadIdMarker></NextUploadIdMarker><EncodingType></EncodingType><MaxUploads>1000</MaxUploads><IsTruncated>false</IsTruncated><Prefix></Prefix><Delimiter></Delimiter></ListMultipartUploadsResult>')
@@ -889,7 +915,7 @@ describe('Client', function() {
             etag: 'etag2'
           })
           MockResponse('http://localhost:9000').put('/bucket/object?partNumber=3&uploadId=uploadid', (body) => {
-            return body.length === 1 * 1024 * 1024
+            return body.length === 2 * 1024 * 1024
 
           }).reply(200, '', {
             etag: 'etag3'


### PR DESCRIPTION
This PR adds a new stream uploader, `.streamObject()`, which allows for easy uploading of a stream to s3.

This also ports `.fPutObject()` and `.putObject()` to use `.streamObject()` under the hood.

**NOTE**: this contains a breaking change. Before this, uploading a stream of size 1GB (for example) but declaring it as 2GB would leave the multipart upload open on the server. This PR now makes it close the multipart upload once the stream ends. The tests have been updated/removed for that.
