### PR TITLE
add `listenBucketNotification`

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -37,7 +37,7 @@ var s3Client = new Minio({
 | [`makeBucket`](#makeBucket)    | [`getObject`](#getObject) | [`presignedGetObject`](#presignedGetObject) | [`getBucketNotification`](#getBucketNotification) |
 | [`listBuckets`](#listBuckets)  | [`getPartialObject`](#getPartialObject)    |   [`presignedPutObject`](#presignedPutObject) | [`setBucketNotification`](#setBucketNotification) |
 | [`bucketExists`](#bucketExists) | [`fGetObject`](#fGetObject)    |    [`presignedPostPolicy`](#presignedPostPolicy) | [`removeAllBucketNotification`](#removeAllBucketNotification) |
-| [`removeBucket`](#removeBucket)      | [`putObject`](#putObject)       |     | [`getBucketPolicy`](#getBucketPolicy)
+| [`removeBucket`](#removeBucket)      | [`putObject`](#putObject)       |     | [`getBucketPolicy`](#getBucketPolicy) | [`listenBucketNotification`](#listenBucketNotification) |
 | [`listObjects`](#listObjects) | [`fPutObject`](#fPutObject)   |   |   [`setBucketPolicy`](#setBucketPolicy)
 | [`listObjectsV2`](#listObjectsV2) | [`statObject`](#statObject)   |
 | [`listIncompleteUploads`](#listIncompleteUploads) | |
@@ -904,6 +904,40 @@ minioClient.removeAllBucketNotification('my-bucketname', function(e) {
     return console.log(e)
   }
   console.log("True")
+})
+```
+
+<a name="listenBucketNotification"></a>
+### listenBucketNotification(bucketName, notificationARN)
+
+Listen for notifications on a bucket, using the given notification ARN. The bucket
+must already have a notification configuration set.
+
+Returns an `EventEmitter`, which will emit a `notification` event carrying the record.
+
+To stop listening, call `.stop()` on the returned `EventEmitter`.
+
+__Parameters__
+
+| Param  |  Type | Description  |
+|---|---|---|
+| `bucketName`  | _string_  | Name of the bucket |
+| `notificationARN`  | _string_  | Amazon Resource Name, built using `Minio.buildARN`. |
+
+See [here](../examples/minio/listen-bucket-notification.js) for a full example.
+
+```js
+// 'us-east-1' may have to be replaced with your bucket region (use `getBucketRegion`).
+// '123' is an account ID, which need not be changed.
+var arn = Minio.buildARN('minio', 'sns', 'us-east-1', '123', 'listen')
+
+var listener = minioClient.listenBucketNotification('my-bucketname', arn)
+
+listener.on('notification', function(record) {
+  // For example: 's3:ObjectCreated:Put event occurred (2016-08-23T18:26:07.214Z)'
+  console.log('%s event occurred (%s)', record.eventName, record.eventTime)
+
+  listener.stop()
 })
 ```
 

--- a/examples/minio/listen-bucket-notification.js
+++ b/examples/minio/listen-bucket-notification.js
@@ -1,0 +1,84 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note that `listenBucketNotification` is only available for Minio, and not
+// Amazon.
+
+const Minio = require('../')
+
+var s3Client = new Minio.Client({
+  endPoint: '...',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+s3Client.getBucketRegion('bucket1', (err, location) => {
+    // Build an ARN. `minio`, `sns`, and `listen` are all standard and need
+    // not be changed. Only `location` must be loaded, and the account ID
+    // (`123`) doesn't matter.
+    let arn = Minio.buildARN('minio', 'sns', location, '123', 'listen')
+
+    // For this example, we'll listen for object creations.
+    let topic = new Minio.TopicConfig(arn)
+    topic.addEvent(Minio.ObjectCreatedAll)
+
+    // Create a new notification config. This will allow us to tell s3 to notify
+    // us when our events happen.
+    let bucketNotification = new Minio.NotificationConfig();
+    bucketNotification.add(topic)
+
+    // We need to update the bucket notification config in order to receive updates.
+    s3Client.setBucketNotification('bucket1', bucketNotification, function(err) {
+        if (err) throw err
+
+        // Start listening for notifications on the bucket, using our arn.
+        let poller = s3Client.listenBucketNotification('bucket1', arn)
+
+        // Notification will be emitted every time a new notification is received.
+        // For object creation, here is a sample record:
+
+        // { eventVersion: '2.0',
+        //   eventSource: 'aws:s3',
+        //   awsRegion: 'us-east-1',
+        //   eventTime: '2016-08-23T18:26:07.214Z',
+        //   eventName: 's3:ObjectCreated:Put',
+        //   userIdentity: { principalId: 'minio' },
+        //   requestParameters: { sourceIPAddress: '...' },
+        //   responseElements: {},
+        //   s3:
+        //    { s3SchemaVersion: '1.0',
+        //      configurationId: 'Config',
+        //      bucket:
+        //       { name: 'bucket1',
+        //         ownerIdentity: [Object],
+        //         arn: 'arn:aws:s3:::bucket1' },
+        //      object: { key: 'object', size: 10, sequencer: '...' } } }
+
+        poller.on('notification', record => {
+            console.log('New object: %s/%s (size: %d)', record.s3.bucket.name,
+                        record.s3.object.key, record.s3.object.size)
+
+            // Now that we've received our notification, we can cancel the listener.
+            // We could leave it open if we wanted to continue to receive notifications.
+            poller.stop()
+        })
+
+        // Create an object - this should trigger a notification.
+        s3Client.putObject('bucket1', 'file.jpg', 'stringdata', (err, etag) => {
+            if (err) throw err
+        })
+    })
+})

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "block-stream2": "^1.0.0",
     "concat-stream": "^1.4.8",
     "es6-error": "^2.0.2",
+    "json-stream": "^1.0.0",
     "lodash": "^4.14.2",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.3",

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -51,7 +51,7 @@ import * as errors from './errors.js';
 
 import { getS3Endpoint } from './s3-endpoints.js';
 
-import { NotificationConfig } from './notification'
+import { NotificationConfig, NotificationPoller } from './notification'
 
 var Package = require('../../package.json');
 
@@ -2035,6 +2035,21 @@ export class Client {
         .on('error', e => cb(e))
         .on('end', () => cb(null, bucketNotification))
     })
+  }
+
+  // Listens for bucket notifications. Returns an EventEmitter.
+  listenBucketNotification(bucketName, notificationARN) {
+    if (!isValidBucketName(bucketName)) {
+      throw new errors.InvalidBucketNameError(`Invalid bucket name: ${bucketName}`)
+    }
+    if (typeof notificationARN !== 'string') {
+      throw new TypeError('notificationARN must be of type string')
+    }
+
+    let listener = new NotificationPoller(this, bucketName, notificationARN)
+    listener.start()
+
+    return listener
   }
 }
 

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -18,7 +18,8 @@ import * as xmlParsers from './xml-parsers.js'
 import { parseBucketPolicy } from './bucket-policy.js'
 import * as _ from 'lodash'
 import Through2 from 'through2'
-import Crypto from 'crypto';
+import Crypto from 'crypto'
+import JSONParser from 'json-stream'
 
 import { isFunction } from './helpers.js'
 import * as errors from './errors.js'
@@ -204,6 +205,12 @@ export function getBucketRegionTransformer() {
 // Parses GET/SET BucketNotification response
 export function getBucketNotificationTransformer() {
   return getConcater(xmlParsers.parseBucketNotification)
+}
+
+// Parses a notification.
+export function getNotificationTransformer() {
+  // This will parse and return each object.
+  return new JSONParser()
 }
 
 // Parses GET BucketPolicy response.

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -1017,6 +1017,17 @@ describe('Client', function() {
       })
     })
 
+    describe('#listenBucketNotification', () => {
+      it('should error on invalid arguments', () => {
+        assert.throws(() => {
+          client.listenBucketNotification('ab', 'arn')
+        }, /Invalid bucket name/)
+        assert.throws(() => {
+          client.listenBucketNotification('bucket', { lol: 49 })
+        }, /notificationARN must be of type string/)
+      })
+    })
+
     describe('#listObjects()', () => {
       it('should iterate without a prefix', (done) => {
         MockResponse('http://localhost:9000').get('/bucket?max-keys=1000').reply(200, '<ListBucketResult xmlns="http://s3.amazonaws.com/doc/2006-03-01"><Name>bucket</Name><Prefix></Prefix><Marker></Marker><MaxKeys>1000</MaxKeys><Delimiter></Delimiter><IsTruncated>true</IsTruncated><Contents><Key>key1</Key><LastModified>2015-05-05T02:21:15.716Z</LastModified><ETag>"5eb63bbbe01eeed093cb22bb8f5acdc3"</ETag><Size>11</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents><Contents><Key>key2</Key><LastModified>2015-05-05T20:36:17.498Z</LastModified><ETag>"2a60eaffa7a82804bdc682ce1df6c2d4"</ETag><Size>1661</Size><StorageClass>STANDARD</StorageClass><Owner><ID>minio</ID><DisplayName>minio</DisplayName></Owner></Contents></ListBucketResult>')


### PR DESCRIPTION
This commit adds `listenBucketNotification`, a method that will
automatically poll s3 for updates on a specific bucket config. This also
adds examples and documentation, although the tests are lacking.

Functional tests were not added because `listenBucketNotification` doesn't work on Amazon.