### PR TITLE
Do not modify global http(s) agent, instead construct an agent per transport.

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -80,14 +80,14 @@ export class Client {
     // Validate if configuration is not using SSL
     // for constructing relevant endpoints.
     if (params.secure === false) {
-      transport = Http
+      transport = new Http.Agent({ keepAlive: true })
       protocol = 'http:'
       if (port === 0) {
         port = 80
       }
     } else {
       // Defaults to secure.
-      transport = Https
+      transport = new Https.Agent({ keepAlive: true })
       protocol = 'https:'
       if (port === 0) {
         port = 443
@@ -111,9 +111,7 @@ export class Client {
     var libraryAgent = `Minio ${libraryComments} minio-js/${Package.version}`
     // User agent block ends.
 
-    // enable connection reuse and pooling
-    this.agent = new transport.Agent({ keepAlive: true })
-
+    this.transport = transport
     this.host = host
     this.port = port
     this.protocol = protocol
@@ -365,7 +363,7 @@ export class Client {
         var authorization = signV4(reqOptions, this.accessKey, this.secretKey, region)
         reqOptions.headers.authorization = authorization
       }
-      var req = this.agent.request(reqOptions, response => {
+      var req = this.transport.request(reqOptions, response => {
         if (statusCode !== response.statusCode) {
           // For an incorrect region, S3 server always sends back 400.
           // But we will do cache invalidation for all errors so that,

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -80,14 +80,14 @@ export class Client {
     // Validate if configuration is not using SSL
     // for constructing relevant endpoints.
     if (params.secure === false) {
-      transport = new Http.Agent({ keepAlive: true })
+      transport = Http
       protocol = 'http:'
       if (port === 0) {
         port = 80
       }
     } else {
       // Defaults to secure.
-      transport = new Https.Agent({ keepAlive: true })
+      transport = Https
       protocol = 'https:'
       if (port === 0) {
         port = 443
@@ -111,6 +111,7 @@ export class Client {
     var libraryAgent = `Minio ${libraryComments} minio-js/${Package.version}`
     // User agent block ends.
 
+    this.agent = new transport.Agent({ keepAlive: true });
     this.transport = transport
     this.host = host
     this.port = port
@@ -195,6 +196,9 @@ export class Client {
       // have all header keys in lower case - to make signing easy
       _.map(headers, (v, k) => reqOptions.headers[k.toLowerCase()] = v)
     }
+
+    // Use the Minio agent with keep-alive
+    reqOptions.agent = this.agent;
 
     return reqOptions
   }

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -112,7 +112,7 @@ export class Client {
     // User agent block ends.
 
     // enable connection reuse and pooling
-    transport.globalAgent.keepAlive = true
+    this.agent = new transport.Agent({ keepAlive: true })
 
     this.host = host
     this.port = port
@@ -123,7 +123,6 @@ export class Client {
     if (!this.accessKey) this.accessKey = ''
     if (!this.secretKey) this.secretKey = ''
     this.anonymous = !this.accessKey || !this.secretKey
-    this.transport = transport
     this.regionMap = {}
     this.minimumPartSize = 5*1024*1024
     this.maximumPartSize = 5*1024*1024*1024
@@ -366,7 +365,7 @@ export class Client {
         var authorization = signV4(reqOptions, this.accessKey, this.secretKey, region)
         reqOptions.headers.authorization = authorization
       }
-      var req = this.transport.request(reqOptions, response => {
+      var req = this.agent.request(reqOptions, response => {
         if (statusCode !== response.statusCode) {
           // For an incorrect region, S3 server always sends back 400.
           // But we will do cache invalidation for all errors so that,


### PR DESCRIPTION
Replace #534

Partial fix for #535, a request stream will work most of the time but is this stream is also 'keep-alive' the library still not handle the problem and won't free the connection
