### PR TITLE
contentType variable was not declared.

### DIFF
--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -130,10 +130,9 @@ export function isValidDomain(host) {
 // Probes contentType using file extensions.
 // For example: probeContentType('file.png') returns 'image/png'.
 export function probeContentType(path) {
-  if (!mime.lookup(path)) {
+  let contentType = mime.lookup(path)
+  if (!contentType) {
     contentType = 'application/octet-stream'
-  } else {
-    contentType = mime.lookup(filePath)
   }
   return contentType
 }


### PR DESCRIPTION
```
krishna@escape:~/dev$ cat fput-object-s3.js
var Minio = require('./minio-js')
var Fs = require('fs')

// find out your s3 end point here:
// http://docs.aws.amazon.com/general/latest/gr/rande.html#s3_region

var s3Client = new Minio.Client({
  endPoint: 's3.amazonaws.com',
   secure: false,
    accessKey: 'XXXXX',
  secretKey: 'XXXX'
})
s3Client.traceOn()
s3Client.fPutObject('krisupload', 'passwd', '/etc/passwd', '', function(e, etag) {
  console.log(e, etag)
})

krishna@escape:~/dev$ node fput-object-s3.js

/home/krishna/dev/minio-js/dist/main/helpers.js:134
    contentType = 'application/octet-stream'
               ^
ReferenceError: contentType is not defined
    at probeContentType (/home/krishna/dev/minio-js/dist/main/helpers.js:134:16)
    at Client.fPutObject (/home/krishna/dev/minio-js/dist/main/minio.js:841:21)
    at Object.<anonymous> (/home/krishna/dev/fput-object-s3.js:30:10)
    at Module._compile (module.js:556:32)
    at Object.Module._extensions..js (module.js:565:10)
    at Module.load (module.js:473:32)
    at tryModuleLoad (module.js:432:12)
    at Function.Module._load (module.js:424:3)
    at Module.runMain (module.js:590:10)
    at run (bootstrap_node.js:394:7)
krishna@escape:~/dev$
```