### PR TITLE
Update source-map-support version

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "mime-types": "^2.1.14",
     "mkdirp": "^0.5.1",
     "moment": "^2.10.3",
-    "source-map-support": "^0.2.10",
+    "source-map-support": "^0.4.12",
     "through2": "^0.6.5",
     "xml": "^1.0.0",
     "xml2js": "^0.4.15"


### PR DESCRIPTION
When running tests using `minio-js` with Jest and jsdom it was throwing errors due to minio-js using an old version of `source-map-support`.

```
/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:486
        throw new DOMException(DOMException.SYNTAX_ERR);
        ^
SyntaxError
    at XMLHttpRequest.open (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/jsdom/lib/jsdom/living/xmlhttprequest.js:486:15)
    at retrieveSourceMapURL (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:61:9)
    at retrieveSourceMap (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:86:26)
    at mapSourcePosition (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:116:21)
    at wrapCallSite (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:270:20)
    at /Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:304:26
    at Array.map (native)
    at Function.prepareStackTrace (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/minio/node_modules/source-map-support/source-map-support.js:303:24)
    at Function.captureStackTrace (<anonymous>)
    at S3Error.ExtendableError (/Users/will3942/work/spotlightdata/nanowire-rubix/node_modules/es6-error/dist/index.js:37:13)
```