### PR TITLE
remove 'finish' handlers on request

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -403,7 +403,6 @@ export class Client {
           this.logHTTP(reqOptions, null, e)
           cb(e)
         })
-      req.once('finish', () => pipe.removeAllListeners('error'));
     }
     if (region) return _makeRequest(null, region)
     this.getBucketRegion(options.bucketName, _makeRequest)


### PR DESCRIPTION
'finish' event was fired before 'error' event causing removal of
error handlers and hence causing the application to crash