### PR TITLE
Add Promise-based API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -96,7 +96,7 @@ var s3Client = new Minio.Client({
 ## 2. Bucket operations
 <a name="makeBucket"></a>
 
-### makeBucket(bucketName, region, callback)
+### makeBucket(bucketName, region[, callback])
 
 Creates a new bucket.
 
@@ -116,7 +116,7 @@ __Parameters__
 | | |ap-southeast-2|
 | | |sa-east-1|
 | | |cn-north-1|
-|`callback(err)`  |_function_   | Callback function with `err` as the error argument. `err` is null if the bucket is successfully created.   |
+|`callback(err)`  |_function_   | Callback function with `err` as the error argument. `err` is null if the bucket is successfully created. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -130,7 +130,7 @@ minioClient.makeBucket('mybucket', 'us-east-1', function(err) {
 ```
 
 <a name="listBuckets"></a>
-### listBuckets(callback)
+### listBuckets([callback])
 
 Lists all buckets.
 
@@ -140,7 +140,7 @@ __Parameters__
 
 | Param  | Type  | Description  |
 |---|---|---|
-|`callback(err, bucketStream) `  | _function_  | Callback function with error as the first argument. bucketStream is the stream emitting bucket information. |
+|`callback(err, bucketStream) `  | _function_  | Callback function with error as the first argument. `bucketStream` is the stream emitting bucket information. If no callback is passed, a `Promise` is returned. |
 
 bucketStream emits Object with the format:-
 
@@ -162,7 +162,7 @@ minioClient.listBuckets(function(err, buckets) {
 ```
 
 <a name="bucketExists"></a>
-#### bucketExists(bucketName, callback)
+#### bucketExists(bucketName[, callback])
 
 Checks if a bucket exists.
 
@@ -173,7 +173,7 @@ __Parameters__
 | Param  | Type  | Description  |
 |---|---|---|
 | `bucketName`  |  _string_ | Name of the bucket.  |
-| `callback(err)`  | _function_  | `err` is `null` if the bucket exists. `err.code` is `NoSuchBucket` in case the bucket does not exist. |
+| `callback(err)`  | _function_  | `err` is `null` if the bucket exists. `err.code` is `NoSuchBucket` in case the bucket does not exist. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -190,7 +190,7 @@ minioClient.bucketExists('mybucket', function(err) {
 ```
 
 <a name="removeBucket"></a>
-### removeBucket(bucketName, callback)
+### removeBucket(bucketName[, callback])
 
 Removes a bucket.
 
@@ -200,7 +200,7 @@ __Parameters__
 | Param  |  Type | Description  |
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket.  |
-| `callback(err)`  | _function_  |  `err` is `null` if the bucket is removed successfully. |
+| `callback(err)`  | _function_  |  `err` is `null` if the bucket is removed successfully. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -340,7 +340,7 @@ Stream.on('error', function(err) {
 ## 3.  Object operations
 
 <a name="getObject"></a>
-### getObject(bucketName, objectName, callback)
+### getObject(bucketName, objectName[, callback])
 
 Downloads an object as a stream.
 
@@ -351,7 +351,7 @@ __Parameters__
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket.  |
 | `objectName`  | _string_  |  Name of the object. |
-| `callback(err, stream)` | _function_ | Callback is called with `err` in case of error. `stream` is the object content stream.|
+| `callback(err, stream)` | _function_ | Callback is called with `err` in case of error. `stream` is the object content stream. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -374,7 +374,7 @@ minioClient.getObject('mybucket', 'photo.jpg', function(err, dataStream) {
 })
 ```
 <a name="getPartialObject"></a>
-### getPartialObject(bucketName, objectName, offset, length, callback)
+### getPartialObject(bucketName, objectName, offset, length[, callback])
 
 Downloads the specified range bytes of an object as a stream.
 
@@ -387,7 +387,7 @@ __Parameters__
 | `objectName`   | _string_  | Name of the object.  |
 | `offset`   | _number_  | `offset` of the object from where the stream will start.  |
 | `length`  | _number_  | `length` of the object that will be read in the stream (optional, if not specified we read the rest of the file from the offset).  |
-|`callback(err, stream)` | _function_  | Callback is called with `err` in case of error. `stream` is the object content stream.|
+|`callback(err, stream)` | _function_  | Callback is called with `err` in case of error. `stream` is the object content stream. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -412,7 +412,7 @@ minioClient.getPartialObject('mybucket', 'photo.jpg', 10, 30, function(err, data
 ```
 
 <a name="fGetObject"></a>
-### fGetObject(bucketName, objectName, filePath, callback)
+### fGetObject(bucketName, objectName, filePath[, callback])
 
 Downloads and saves the object as a file in the local filesystem.
 
@@ -423,7 +423,7 @@ __Parameters__
 | `bucketName`  | _string_   | Name of the bucket.  |
 | `objectName`  |_string_   | Name of the object.  |
 | `filePath`  |  _string_ | Path on the local filesystem to which the object data will be written.  |
-| `callback(err)`  | _function_  | Callback is called with `err` in case of error.  |
+| `callback(err)`  | _function_  | Callback is called with `err` in case of error. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -439,7 +439,7 @@ minioClient.fGetObject('mybucket', 'photo.jpg', '/tmp/photo.jpg', function(err) 
 })
 ```
 <a name="putObject"></a>
-### putObject(bucketName, objectName, stream, size, contentType, callback)
+### putObject(bucketName, objectName, stream, size, contentType[, callback])
 
 Uploads an object from a stream/Buffer.
 
@@ -456,7 +456,7 @@ __Parameters__
 | `stream`  | _Stream_  |Readable stream.   |
 |`size`   | _number_  | Size of the object (optional).  |
 |`contentType`   | _string_  | Content-Type of the object (optional, default `application/octet-stream`).  |
-| `callback(err, etag)` | _function_ | Non-null `err` indicates error, `etag` _string_ is the etag of the object uploaded.|
+| `callback(err, etag)` | _function_ | Non-null `err` indicates error, `etag` _string_ is the etag of the object uploaded. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -501,7 +501,7 @@ minioClient.putObject('mybucket', 'hello-file', buffer, function(err, etag) {
 })
 ```
 <a name="fPutObject"></a>
-### fPutObject(bucketName, objectName, filePath, contentType, callback)
+### fPutObject(bucketName, objectName, filePath, contentType[, callback])
 
 Uploads contents from a file to objectName.
 
@@ -514,7 +514,7 @@ __Parameters__
 |`objectName`   |_string_   | Name of the object.  |
 | `filePath`  | _string_  | Path of the file to be uploaded.  |
 | `contentType`  | _string_  | Content-Type of the object.  |
-| `callback(err, etag)`  |  _function_ | Non-null `err` indicates error, `etag` _string_ is the etag of the object uploaded.  |
+| `callback(err, etag)`  |  _function_ | Non-null `err` indicates error, `etag` _string_ is the etag of the object uploaded. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -529,7 +529,7 @@ minioClient.fPutObject('mybucket', '40mbfile', file, 'application/octet-stream',
 ```
 
 <a name="copyObject"></a>
-### copyObject(bucketName, objectName, sourceObject, conditions, callback)
+### copyObject(bucketName, objectName, sourceObject, conditions[, callback])
 
 Copy a source object into a new object in the specied bucket.
 
@@ -542,7 +542,7 @@ __Parameters__
 |`objectName`   |_string_   | Name of the object.  |
 | `sourceObject`  | _string_  | Path of the file to be copied.  |
 | `conditions`  | _CopyConditions_  | Conditions to be satisfied before allowing object copy.  |
-| `callback(err, {etag, lastModified})`  |  _function_ | Non-null `err` indicates error, `etag` _string_ and lastModified _Date_ are the etag and the last modified date of the object newly copied. |
+| `callback(err, {etag, lastModified})`  |  _function_ | Non-null `err` indicates error, `etag` _string_ and lastModified _Date_ are the etag and the last modified date of the object newly copied. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 
@@ -560,7 +560,7 @@ minioClient.copyObject('mybucket', 'newobject', '/mybucket/srcobject', conds, fu
 
 
 <a name="statObject"></a>
-### statObject(bucketName, objectName, callback)
+### statObject(bucketName, objectName[, callback])
 
 Gets metadata of an object.
 
@@ -571,7 +571,7 @@ __Parameters__
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket.  |
 | `objectName`  | _string_  | Name of the object.  |
-| `callback(err, stat)`  | _function_  |`err` is not `null` in case of error, `stat` contains the object information listed below: |
+| `callback(err, stat)`  | _function_  |`err` is not `null` in case of error, `stat` contains the object information listed below. If no callback is passed, a `Promise` is returned. |
 
 
 
@@ -596,7 +596,7 @@ minioClient.statObject('mybucket', 'photo.jpg', function(err, stat) {
 ```
 
 <a name="removeObject"></a>
-### removeObject(bucketName, objectName, callback)
+### removeObject(bucketName, objectName[, callback])
 
 Removes an object.
 
@@ -607,7 +607,7 @@ __Parameters__
 |---|---|---|
 |`bucketName`   |  _string_ | Name of the bucket.  |
 | objectName  |  _string_ | Name of the object.  |
-| `callback(err)`  | _function_  | Callback function is called with non `null` value in case of error.  |
+| `callback(err)`  | _function_  | Callback function is called with non `null` value in case of error. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -623,7 +623,7 @@ minioClient.removeObject('mybucket', 'photo.jpg', function(err) {
 ```
 
 <a name="removeIncompleteUpload"></a>
-### removeIncompleteUpload(bucketName, objectName, callback)
+### removeIncompleteUpload(bucketName, objectName[, callback])
 
 Removes a partially uploaded object.
 
@@ -634,7 +634,7 @@ __Parameters__
 |---|---|---|
 | `bucketName`  |_string_   | Name of the bucket.  |
 | `objectName`  | _string_  | Name of the object.  |
-| `callback(err)`  | _function_  |Callback function is called with non `null` value in case of error.   |
+| `callback(err)`  | _function_  |Callback function is called with non `null` value in case of error. If no callback is passed, a `Promise` is returned.  |
 
 
 __Example__
@@ -654,7 +654,7 @@ minioClient.removeIncompleteUpload('mybucket', 'photo.jpg', function(err) {
 Presigned URLs are generated for temporary download/upload access to private objects.
 
 <a name="presignedGetObject"></a>
-### presignedGetObject(bucketName, objectName, expiry, cb)
+### presignedGetObject(bucketName, objectName, expiry[, cb])
 
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which the URL is no longer valid. The default expiry is set to 7 days.
 
@@ -668,7 +668,7 @@ __Parameters__
 | `bucketName`  | _string_  | Name of the bucket.  |
 |`objectName`   | _string_  | Name of the object.  |
 | `expiry`  |_number_   | Expiry in seconds. Default expiry is set to 7 days.  |
-| `callback(err, presignedUrl)`  | _function_  | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request.  |
+| `callback(err, presignedUrl)`  | _function_  | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -683,7 +683,7 @@ minioClient.presignedGetObject('mybucket', 'hello.txt', 24*60*60, function(err, 
 ```
 
 <a name="presignedPutObject"></a>
-### presignedPutObject(bucketName, objectName, expiry, callback)
+### presignedPutObject(bucketName, objectName, expiry[, callback])
 
 Generates a presigned URL for HTTP PUT operations. Browsers/Mobile clients may point to this URL to upload objects directly to a bucket even if it is private.  This presigned URL can have an associated expiration time in seconds after which the URL is no longer valid. The default expiry is set to 7 days.
 
@@ -696,7 +696,7 @@ __Parameters__
 | `bucketName`  | _string_  | Name of the bucket.  |
 | `objectName`  | _string_  | Name of the object.  |
 | `expiry`  | _number_   | Expiry in seconds. Default expiry is set to 7 days.  |
-| `callback(err, presignedUrl)`  | _function_  | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be uploaded using PUT request.  |
+| `callback(err, presignedUrl)`  | _function_  | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be uploaded using PUT request. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -711,7 +711,7 @@ minioClient.presignedPutObject('mybucket', 'hello.txt', 24*60*60, function(err, 
 ```
 
 <a name="presignedPostPolicy"></a>
-### presignedPostPolicy(policy, callback)
+### presignedPostPolicy(policy[, callback])
 
 Allows setting policy conditions to a presigned URL for POST operations. Policies such as bucket name to receive object uploads, key name prefixes, expiry policy may be set.
 
@@ -721,7 +721,7 @@ __Parameters__
 | Param  |  Type | Description  |
 |---|---|---|
 | `policy`  | _object_  | Policy object created by minioClient.newPostPolicy() |
-| `callback(err, postURL, formData)`  | _function_  | Callback function is called with non `null` err value in case of error. `postURL` will be the URL using which the object can be uploaded using POST request. `formData` is the object having key/value pairs for the Form data of POST body. |
+| `callback(err, postURL, formData)`  | _function_  | Callback function is called with non `null` err value in case of error. `postURL` will be the URL using which the object can be uploaded using POST request. `formData` is the object having key/value pairs for the Form data of POST body. If no callback is passed, a `Promise` is returned. |
 
 
 Create policy:
@@ -787,7 +787,7 @@ minioClient.presignedPostPolicy(policy, function(err, postURL, formData) {
 Buckets are configured to trigger notifications on specified types of events and paths filters.
 
 <a name="getBucketNotification"></a>
-### getBucketNotification(bucketName, cb)
+### getBucketNotification(bucketName[, cb])
 
 Fetch the notification configuration stored in the S3 provider and that belongs to the specified bucket name.
 
@@ -798,7 +798,7 @@ __Parameters__
 | Param  |  Type | Description  |
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket.  |
-| `callback(err, bucketNotificationConfig)`  | _function_  | Callback function is called with non `null` err value in case of error. `bucketNotificationConfig` will be the object that carries all notification configurations associated to bucketName.  |
+| `callback(err, bucketNotificationConfig)`  | _function_  | Callback function is called with non `null` err value in case of error. `bucketNotificationConfig` will be the object that carries all notification configurations associated to bucketName. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -812,7 +812,7 @@ minioClient.getBucketNotification('mybucket', function(err, bucketNotificationCo
 ```
 
 <a name="setBucketNotification"></a>
-### setBucketNotification(bucketName, bucketNotificationConfig, callback)
+### setBucketNotification(bucketName, bucketNotificationConfig[, callback])
 
 Upload a user-created notification configuration and associate it to the specified bucket name.
 
@@ -824,7 +824,7 @@ __Parameters__
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket.  |
 | `bucketNotificationConfig`  | _BucketNotification_   | Javascript object that carries the notification configuration.  |
-| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error.  |
+| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. If no callback is passed, a `Promise` is returned. |
 
 
 __Example__
@@ -851,7 +851,7 @@ minioClient.setBucketNotification('mybucket', bucketNotification, function(err) 
 ```
 
 <a name="removeAllBucketNotification"></a>
-### removeAllBucketNotification(bucketName, callback)
+### removeAllBucketNotification(bucketName[, callback])
 
 Remove the bucket notification configuration associated to the specified bucket.
 
@@ -861,7 +861,7 @@ __Parameters__
 | Param  |  Type | Description  |
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket |
-| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. |
+| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. If no callback is passed, a `Promise` is returned. |
 
 
 ```js
@@ -906,7 +906,7 @@ listener.on('notification', function(record) {
 ```
 
 <a name="getBucketPolicy"></a>
-### getBucketPolicy(bucketName, objectPrefix, callback)
+### getBucketPolicy(bucketName, objectPrefix[, callback])
 
 Get the bucket policy associated with the specified bucket. If `objectPrefix`
 is not empty, the bucket policy will be filtered based on object permissions
@@ -919,7 +919,7 @@ __Parameters__
 |---|---|---|
 | `bucketName`  | _string_  | Name of the bucket |
 | `objectPrefix` | _string_ | Prefix of objects in the bucket with which to filter permissions off of. Use `''` for entire bucket. |
-| `callback(err, policy)`  | _function_  | Callback function is called with non `null` err value in case of error. `policy` will be the string representation of the bucket policy (`minio.Policy.NONE`, `minio.Policy.READONLY`, `minio.Policy.WRITEONLY`, or `minio.Policy.READWRITE`). |
+| `callback(err, policy)`  | _function_  | Callback function is called with non `null` err value in case of error. `policy` will be the string representation of the bucket policy (`minio.Policy.NONE`, `minio.Policy.READONLY`, `minio.Policy.WRITEONLY`, or `minio.Policy.READWRITE`). If no callback is passed, a `Promise` is returned. |
 
 
 ```js
@@ -933,7 +933,7 @@ minioClient.getBucketPolicy('my-bucketname', 'img-', function(err, policy) {
 ```
 
 <a name="setBucketPolicy"></a>
-### setBucketPolicy(bucketName, objectPrefix, bucketPolicy, callback)
+### setBucketPolicy(bucketName, objectPrefix, bucketPolicy[, callback])
 
 Set the bucket policy associated with the specified bucket. If `objectPrefix`
 is not empty, the bucket policy will only be assigned to objects that fit the
@@ -947,7 +947,7 @@ __Parameters__
 | `bucketName`  | _string_  | Name of the bucket |
 | `objectPrefix` | _string_ | Prefix of objects in the bucket to modify permissions of. Use `''` for entire bucket. |
 | `bucketPolicy` | _string_ | The bucket policy. This can be: `minio.Policy.NONE`, `minio.Policy.READONLY`, `minio.Policy.WRITEONLY`, or `minio.Policy.READWRITE`. |
-| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. |
+| `callback(err)`  | _function_  | Callback function is called with non `null` err value in case of error. If no callback is passed, a `Promise` is returned. |
 
 
 ```js

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -17,6 +17,34 @@
 import stream from 'stream'
 import mime from 'mime-types'
 
+// Returns a wrapper function that will promisify a given callback function.
+// It will preserve 'this'.
+export function promisify(fn) {
+  return function() {
+    // If the last argument is a function, assume its the callback.
+    let callback = arguments[arguments.length - 1]
+
+    // If the callback is given, don't promisify, just pass straight in.
+    if (typeof callback === 'function') return fn.apply(this, arguments)
+
+    // Otherwise, create a new set of arguments, and wrap
+    // it in a promise.
+    let args = [...arguments]
+
+    return new Promise((resolve, reject) => {
+      // Add the callback function.
+      args.push((err, value) => {
+        if (err) return reject(err)
+
+        resolve(value)
+      })
+
+      // Call the function with our special adaptor callback added.
+      fn.apply(this, args)
+    })
+  }
+}
+
 // All characters in string which are NOT unreserved should be percent encoded.
 // Unreserved characers are : ALPHA / DIGIT / "-" / "." / "_" / "~"
 // Reference https://tools.ietf.org/html/rfc3986#section-2.2

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -34,7 +34,7 @@ import { isValidPrefix, isValidEndpoint, isValidBucketName,
   uriEscape, uriResourceEscape, isBoolean, isFunction, isNumber,
   isString, isObject, isArray, pipesetup,
   readableStream, isReadableStream, isVirtualHostStyle,
-  probeContentType, makeDateLong } from './helpers.js'
+  probeContentType, makeDateLong, promisify } from './helpers.js'
 
 import { signV4, presignSignatureV4, postPresignSignatureV4 } from './signing.js'
 
@@ -2014,6 +2014,32 @@ export class Client {
     return listener
   }
 }
+
+// Promisify various public-facing APIs on the Client module.
+Client.prototype.makeBucket = promisify(Client.prototype.makeBucket)
+Client.prototype.listBuckets = promisify(Client.prototype.listBuckets)
+Client.prototype.bucketExists = promisify(Client.prototype.bucketExists)
+Client.prototype.removeBucket = promisify(Client.prototype.removeBucket)
+
+Client.prototype.getObject = promisify(Client.prototype.getObject)
+Client.prototype.getPartialObject = promisify(Client.prototype.getPartialObject)
+Client.prototype.fGetObject = promisify(Client.prototype.fGetObject)
+Client.prototype.putObject = promisify(Client.prototype.putObject)
+Client.prototype.fPutObject = promisify(Client.prototype.fPutObject)
+Client.prototype.copyObject = promisify(Client.prototype.copyObject)
+Client.prototype.statObject = promisify(Client.prototype.statObject)
+Client.prototype.removeObject = promisify(Client.prototype.removeObject)
+
+Client.prototype.presignedGetObject = promisify(Client.prototype.presignedGetObject)
+Client.prototype.presignedPutObject = promisify(Client.prototype.presignedPutObject)
+Client.prototype.presignedPostPolicy = promisify(Client.prototype.presignedPostPolicy)
+Client.prototype.getBucketNotification = promisify(Client.prototype.getBucketNotification)
+Client.prototype.setBucketNotification = promisify(Client.prototype.setBucketNotification)
+Client.prototype.removeAllBucketNotification = promisify(Client.prototype.removeAllBucketNotification)
+Client.prototype.getBucketPolicy = promisify(Client.prototype.getBucketPolicy)
+Client.prototype.setBucketPolicy = promisify(Client.prototype.setBucketPolicy)
+Client.prototype.removeIncompleteUpload = promisify(Client.prototype.removeIncompleteUpload)
+
 
 export class CopyConditions {
   constructor() {

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -222,14 +222,14 @@ describe('Client', function() {
             port: 9000,
             secure: false
           })
-          client.presignedGetObject('bucket', 'object', 1000)
+          client.presignedGetObject('bucket', 'object', 1000, function() {})
         } catch (e) {
           done()
         }
       })
       it('should not generate presigned url with wrong expires param', (done) => {
         try {
-          client.presignedGetObject('bucket', 'object', '0')
+          client.presignedGetObject('bucket', 'object', '0', function() {})
         } catch (e) {
           done()
         }
@@ -251,14 +251,14 @@ describe('Client', function() {
             port: 9000,
             secure: false
           })
-          client.presignedPutObject('bucket', 'object', 1000)
+          client.presignedPutObject('bucket', 'object', 1000, function() {})
         } catch (e) {
           done()
         }
       })
       it('should not generate presigned url with wrong expires param', (done) => {
         try {
-          client.presignedPutObject('bucket', 'object', '0')
+          client.presignedPutObject('bucket', 'object', '0', function() {})
         } catch (e) {
           done()
         }
@@ -435,21 +435,21 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.makeBucket(null)
+          client.makeBucket(null, '', assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.makeBucket('')
+          client.makeBucket('', '', assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.makeBucket('  \n  \t  ')
+          client.makeBucket('  \n  \t  ', '', assert.fail)
         } catch (e) {
           done()
         }
@@ -507,21 +507,21 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.bucketExists(null)
+          client.bucketExists(null, assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.bucketExists('')
+          client.bucketExists('', assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.BucketExists('  \n  \t  ')
+          client.BucketExists('  \n  \t  ', assert.fail)
         } catch (e) {
           done()
         }
@@ -543,21 +543,21 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.removeBucket(null)
+          client.removeBucket(null, assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeBucket('')
+          client.removeBucket('', assert.fail)
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeBucket('  \n  \t  ')
+          client.removeBucket('  \n  \t  ', assert.fail)
         } catch (e) {
           done()
         }
@@ -650,42 +650,35 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.getObject(null, 'hello')
+          client.getObject(null, 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.getObject('', 'hello')
+          client.getObject('', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.getObject('  \n  \t  ', 'hello')
+          client.getObject('  \n  \t  ', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on null object', (done) => {
         try {
-          client.getObject('hello', null)
+          client.getObject('hello', null, function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty object', (done) => {
         try {
-          client.getObject('hello', '')
-        } catch (e) {
-          done()
-        }
-      })
-      it('should fail on empty object', (done) => {
-        try {
-          client.getObject('hello', '  \n  \t  ')
+          client.getObject('hello', '', function() {})
         } catch (e) {
           done()
         }
@@ -787,15 +780,6 @@ describe('Client', function() {
             client.putObject('bucket', '', () => {})
           }, /Invalid object name/)
         })
-        it('should fail without callback', () => {
-          // Whether or not size is there.
-          assert.throws(() => {
-            client.putObject('bucket', 'object', 'slugz', 5)
-          }, /callback should be of type "function"/)
-          assert.throws(() => {
-            client.putObject('bucket', 'object', new Buffer('slug'))
-          }, /callback should be of type "function"/)
-        })
         it('should error with size > maxObjectSize', () => {
           assert.throws(() => {
             client.putObject('bucket', 'object', new Stream.Readable(), client.maxObjectSize + 1, () => {})
@@ -803,42 +787,35 @@ describe('Client', function() {
         })
         it('should fail on null bucket', (done) => {
           try {
-            client.putObject(null, 'hello', null, 1, '')
+            client.putObject(null, 'hello', null, 1, '', function() {})
           } catch (e) {
             done()
           }
         })
         it('should fail on empty bucket', (done) => {
           try {
-            client.putObject(' \n \t ', 'hello', null, 1, '')
+            client.putObject(' \n \t ', 'hello', null, 1, '', function() {})
           } catch (e) {
             done()
           }
         })
         it('should fail on empty bucket', (done) => {
           try {
-            client.putObject('', 'hello', null, 1, '')
+            client.putObject('', 'hello', null, 1, '', function() {})
           } catch (e) {
             done()
           }
         })
         it('should fail on null object', (done) => {
           try {
-            client.putObject('hello', null, null, 1, '')
+            client.putObject('hello', null, null, 1, '', function() {})
           } catch (e) {
             done()
           }
         })
         it('should fail on empty object', (done) => {
           try {
-            client.putObject('hello', '', null, 1, '')
-          } catch (e) {
-            done()
-          }
-        })
-        it('should fail on empty object', (done) => {
-          try {
-            client.putObject('hello', ' \n \t ', null, 1, '')
+            client.putObject('hello', '', null, 1, '', function() {})
           } catch (e) {
             done()
           }
@@ -1045,11 +1022,8 @@ describe('Client', function() {
     describe('#removeAllBucketNotification()', () => {
       it('should error on invalid arguments', () => {
         assert.throws(() => {
-          client.removeAllBucketNotification('ab', () => {})
+          client.removeAllBucketNotification('ab', () => {}, function() {})
         }, /Invalid bucket name/)
-        assert.throws(() => {
-          client.removeAllBucketNotification('bucket', 13)
-        }, /callback should be of type "function"/)
       })
       it('remove all bucket notifications', (done) => {
         MockResponse('http://localhost:9000').get('/bucket?location').reply(200, '<LocationConstraint xmlns="http://s3.amazonaws.com/doc/2006-03-01/">EU</LocationConstraint>')
@@ -1069,9 +1043,6 @@ describe('Client', function() {
         assert.throws(() => {
           client.setBucketNotification('bucket', 49, () => {})
         }, /notification config should be of type "Object"/)
-        assert.throws(() => {
-          client.setBucketNotification('bucket', {}, 13)
-        }, /callback should be of type "function"/)
       })
       it('set a bucket notification', (done) => {
         MockResponse('http://localhost:9000').put('/bucket?notification').reply(200, '')
@@ -1098,9 +1069,6 @@ describe('Client', function() {
         assert.throws(() => {
           client.getBucketNotification('ab', () => {})
         }, /Invalid bucket name/)
-        assert.throws(() => {
-          client.getBucketNotification('bucket', 13)
-        }, /callback should be of type "function"/)
       })
       it('get and parse a bucket notification response', (done) => {
         MockResponse('http://localhost:9000').get('/bucket?notification').reply(200, '<NotificationConfiguration xmlns="http://s3.amazonaws.com/doc/2006-03-01/"><TopicConfiguration><Id>YjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4</Id><Topic>arn:aws:sns:us-east-1:83310034:s3notificationtopic2</Topic><Event>s3:ReducedRedundancyLostObject</Event><Event>s3:ObjectCreated:*</Event><Filter><S3Key><FilterRule><Name>suffix</Name><Value>.jpg</Value></FilterRule><FilterRule><Name>prefix</Name><Value>photos/</Value></FilterRule></S3Key></Filter></TopicConfiguration><QueueConfiguration><Id>ZjVkM2Y0YmUtNGI3NC00ZjQyLWEwNGItNDIyYWUxY2I0N2M4</Id><Queue>arn:aws:sns:us-east-1:83310034:s3notificationqueue2</Queue><Event>s3:ReducedRedundancyLostObject</Event><Event>s3:ObjectCreated:*</Event></QueueConfiguration></NotificationConfiguration>')
@@ -1369,42 +1337,35 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.statObject(null, 'hello')
+          client.statObject(null, 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.statObject('', 'hello')
+          client.statObject('', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.statObject('  \n  \t  ', 'hello')
+          client.statObject('  \n  \t  ', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on null object', (done) => {
         try {
-          client.statObject('hello', null)
+          client.statObject('hello', null, function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty object', (done) => {
         try {
-          client.statObject('hello', '')
-        } catch (e) {
-          done()
-        }
-      })
-      it('should fail on empty object', (done) => {
-        try {
-          client.statObject('hello', '  \n  \t  ')
+          client.statObject('hello', '', function() {})
         } catch (e) {
           done()
         }
@@ -1427,42 +1388,35 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.removeObject(null, 'hello')
+          client.removeObject(null, 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeObject('', 'hello')
+          client.removeObject('', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeObject('  \n  \t  ', 'hello')
+          client.removeObject('  \n  \t  ', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on null object', (done) => {
         try {
-          client.removeObject('hello', null)
+          client.removeObject('hello', null, function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty object', (done) => {
         try {
-          client.removeObject('hello', '')
-        } catch (e) {
-          done()
-        }
-      })
-      it('should fail on empty object', (done) => {
-        try {
-          client.removeObject('hello', '  \n  \t  ')
+          client.removeObject('hello', '', function() {})
         } catch (e) {
           done()
         }
@@ -1495,42 +1449,35 @@ describe('Client', function() {
       })
       it('should fail on null bucket', (done) => {
         try {
-          client.removeIncompleteUpload(null, 'hello')
+          client.removeIncompleteUpload(null, 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeIncompleteUpload('', 'hello')
+          client.removeIncompleteUpload('', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeIncompleteUpload('  \n  \t  ', 'hello')
+          client.removeIncompleteUpload('  \n  \t  ', 'hello', function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on null object', (done) => {
         try {
-          client.removeIncompleteUpload('hello', null)
+          client.removeIncompleteUpload('hello', null, function() {})
         } catch (e) {
           done()
         }
       })
       it('should fail on empty object', (done) => {
         try {
-          client.removeIncompleteUpload('hello', '')
-        } catch (e) {
-          done()
-        }
-      })
-      it('should fail on empty object', (done) => {
-        try {
-          client.removeIncompleteUpload('hello', '  \n  \t  ')
+          client.removeIncompleteUpload('hello', '', function() {})
         } catch (e) {
           done()
         }


### PR DESCRIPTION
Issue: https://github.com/minio/minio-js/issues/568

This contains the basis for the new Promise-based API. Right now it makes callbacks *optional*, and when no callback is given, it will instead return a Promise. Backwards compatibility is maintained. Tests and documentation have been added.

Right now this only changes actions dealing with buckets, though it is easily scale-able once we decide this is the way to go. **Seeking feedback!**