### PR TITLE
remove moment, use native implementation

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "lodash": "^4.14.2",
     "mime-types": "^2.1.14",
     "mkdirp": "^0.5.1",
-    "moment": "^2.10.3",
     "source-map-support": "^0.4.12",
     "through2": "^0.6.5",
     "uuid": "^3.1.0",

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -53,7 +53,7 @@ export function uriResourceEscape(string) {
 }
 
 export function getScope(region, date) {
-  return `${date.format('YYYYMMDD')}/${region}/s3/aws4_request`
+  return `${makeDateShort(date)}/${region}/s3/aws4_request`
 }
 
 // isAmazonEndpoint - true if endpoint is 's3.amazonaws.com' or 's3.cn-north-1.amazonaws.com.cn'
@@ -222,9 +222,32 @@ export function isArray(arg) {
   return Array.isArray(arg)
 }
 
-// check if arg is Date
-export function isDate(arg) {
-  return arg._isAMomentObject
+// Create a Date string with format:
+// 'YYYYMMDDTHHmmss' + Z
+export function makeDateLong(date) {
+  date = date || new Date()
+
+  // Gives format like: '2017-08-07T16:28:59.889Z'
+  date = date.toISOString()
+
+  return date.substr(0, 4) +
+    date.substr(5, 2) +
+    date.substr(8, 5) +
+    date.substr(14, 2) +
+    date.substr(17, 2) + 'Z'
+}
+
+// Create a Date string with format:
+// 'YYYYMMDD'
+export function makeDateShort(date) {
+  date = date || new Date()
+
+  // Gives format like: '2017-08-07T16:28:59.889Z'
+  date = date.toISOString()
+
+  return date.substr(0, 4) +
+    date.substr(5, 2) +
+    date.substr(8, 2)
 }
 
 // pipesetup sets up pipe() from left to right os streams array

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -333,7 +333,13 @@ describe('functional tests', function() {
     it('should create multipart request', done => {
       client.initiateNewMultipartUpload(bucketName, _6mbObjectName, 'application/octet-stream', done)
     })
-    it('should list incomplete upload', done => {
+    it('should list incomplete upload', function(done) {
+      // Minio's ListIncompleteUploads returns an empty list, so skip this on non-AWS.
+      // See: https://github.com/minio/minio/commit/75c43bfb6c4a2ace
+      if (!client.host.includes('s3.amazonaws.com')) {
+        this.skip()
+      }
+
       var found = false
       client.listIncompleteUploads(bucketName, _6mbObjectName, true)
         .on('error', e => done(e))

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -22,7 +22,7 @@ import Nock from 'nock'
 import Through2 from 'through2'
 import Stream from 'stream'
 import * as Minio from '../../../dist/main/minio'
-import { isValidEndpoint, isValidIP } from '../../../dist/main/helpers'
+import { isValidEndpoint, isValidIP, makeDateLong, makeDateShort } from '../../../dist/main/helpers'
 
 import { parseBucketPolicy, generateBucketPolicy } from '../../../dist/main/bucket-policy'
 
@@ -46,6 +46,58 @@ describe('Helpers', () => {
   })
   it('should fail for invalid ip', () => {
     assert.equal(isValidIP('1.1.1'), false)
+  })
+  it('should make date short', () => {
+    let date = new Date('2012-12-03T17:25:36.331Z')
+
+    assert.equal(makeDateShort(date), '20121203')
+  })
+  it('should make date long', () => {
+    let date = new Date('2017-08-11T17:26:34.935Z')
+
+    assert.equal(makeDateLong(date), '20170811T172634Z')
+  })
+})
+
+describe('CopyConditions', () => {
+  let date = '2017-08-11T19:34:18.437Z'
+
+  let cc = new Minio.CopyConditions()
+
+  describe('#setModified', () => {
+    it('should take a date argument', () => {
+      cc.setModified(new Date(date))
+
+      assert.equal(cc.modified, date)
+    })
+
+    it('should throw without date', () => {
+      assert.throws(() => {
+        cc.setModified()
+      }, /date must be of type Date/)
+
+      assert.throws(() => {
+        cc.setModified({ hi: 'there' })
+      }, /date must be of type Date/)
+    })
+  })
+
+  describe('#setUnmodified', () => {
+    it('should take a date argument', () => {
+      cc.setUnmodified(new Date(date))
+
+      assert.equal(cc.unmodified, date)
+    })
+
+    it('should throw without date', () => {
+      assert.throws(() => {
+        cc.setUnmodified()
+      }, /date must be of type Date/)
+
+      assert.throws(() => {
+        cc.setUnmodified({ hi: 'there' })
+      }, /date must be of type Date/)
+    })
   })
 })
 


### PR DESCRIPTION
This commit removes the dependency on the MomentJS library for
performance, and instead replaces its long/short date formatting
APIs with our own native alternatives.

This also adds unit tests to make sure the date helper functions are
covered.

Fixes: #570

This commit also skips a unit test which began failing after a change in
minio server. It will skip on non-AWS hosts. See:
minio/minio@75c43bf