### PR TITLE
Missing functional tests for minio-js

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -51,6 +51,12 @@ gulp.task('test', ['compile', 'test:compile'], function() {
       reporter: 'spec',
       ui: 'bdd',
     }))
+    .once('error', () => {
+			process.exit(1);
+		})
+		.once('end', () => {
+			process.exit();
+		})
 })
 
 gulp.task('lint', function() {
@@ -69,6 +75,12 @@ gulp.task('functional-test', ['compile'], function() {
         reporter: 'spec',
         ui: 'bdd',
       }))
+      .once('error', () => {
+        process.exit(1);
+      })
+      .once('end', () => {
+        process.exit();
+      })
   })
 })
 

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "homepage": "https://github.com/minio/minio-js#readme",
   "dependencies": {
-    "async": "^1.5.0",
+    "async": "^1.5.2",
     "block-stream2": "^1.0.0",
     "concat-stream": "^1.4.8",
     "es6-error": "^2.0.2",
@@ -45,7 +45,7 @@
   },
   "devDependencies": {
     "browserify": "^12.0.1",
-    "chai": "^3.4.0",
+    "chai": "^3.5.0",
     "eslint": "^4.1.1",
     "gulp": "^3.9.0",
     "gulp-babel": "^5.2.1",
@@ -54,9 +54,10 @@
     "gulp-notify": "^2.2.0",
     "gulp-sourcemaps": "^1.5.2",
     "mocha": "^2.3.2",
+    "mocha-steps": "^1.1.0",
     "nock": "^2.12.0",
     "rewire": "^2.3.3",
-    "superagent": "^1.6.1"
+    "superagent": "^1.8.5"
   },
   "keywords": [
     "api",


### PR DESCRIPTION
Checked tests have been implemented 
- [ ] 1. Based on https://github.com/minio/minio-js/blob/master/src/test/functional/functional-tests.js#L77 block, are all data content created in one short? . We would need to create content on demand with dynamic content generation stream.
- [x] 2. It lacks unknown sized stream test
- [x] 3. remove bucket positive case is missing.
- [x] 4. why putobject string buffer test is important?
This is more a SDK functionality.
- [x] 5. fputobject() single or multipart upload test missing.
- [x] 6. fputobject() with custom content type test is missing.
- [ ] 7. test for putobject() with stream and size missing for multiart resume.
- [x] 8. test for putobject() where object name contains multiple path segment is missing (may be not relevant)
- [x] 9. test for putobject() with stream and custom content type missing.
- [x] 10. test for putobject() stream with unknown size stream using multipart missing.
- [ ] 11. test for putobject() with client side encryption missing ( may be missing feature)
- [x] 12. test for getobject() with offset and/or length is missing.
- [x] 13. test for getobject() multiple path segment is missing (may be not relevant)
- [ ] 14. test for getobject() with client side encryption missing (may be missing feature)
- [x] 15. test for listobjects() with prefix missing.
- [x] 16. test for listobjects() recursive missing.
- [x] 17. test for listobjects() on empty bucket missing.
- [x] 18. test for listobjects() with recursive for > 1000 objects.
- [x] 19. test for listobjects() v1 listing (may be missing feature)
- [x] 20. test for removeobject() removing multiple objects missing.
- [x] 21. test for listincompleteuploads() for prefix missing.
- [x] 22. test for listincompleteuploads() with recursive missing.
- [x] 23. test for presignedgetobject() with default timeout missing.
- [x] 24. test for presignedputobject() with default timeout missing.
- [x] 25. test for parallel use of minio client object (for thread safety) missing. (may be not relevant)
- [x ] 26. test for copyobject() etag:condition matching negative case missing.
- [x] 27. test for copyobject() etag:condition not matching positive/negative cases missing.
- [x] 28. test for copyobject() unmodified:condition (not) matching positive/negative cases missing.
- [ ] 29. test for copyobject() replace meta data mising.
- [ ] 30. TBD bucket notification tests.
- [ ] 31. option to run all tests and quick tests.

The test type has been changed from it to step, to support serial execution of the tests in js.


Fixes (#612)