### PR TITLE
Fix date format in copy conditions

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2053,14 +2053,14 @@ export class CopyConditions {
     if (!(date instanceof Date))
       throw new TypeError('date must be of type Date')
 
-    this.modified = date.toISOString()
+    this.modified = date.toUTCString()
   }
 
   setUnmodified(date) {
     if (!(date instanceof Date))
       throw new TypeError('date must be of type Date')
 
-    this.unmodified = date.toISOString()
+    this.unmodified = date.toUTCString()
   }
 
   setMatchETag(etag) {

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -60,7 +60,7 @@ describe('Helpers', () => {
 })
 
 describe('CopyConditions', () => {
-  let date = '2017-08-11T19:34:18.437Z'
+  let date = 'Fri, 11 Aug 2017 19:34:18 GMT'
 
   let cc = new Minio.CopyConditions()
 


### PR DESCRIPTION
Minio-js is passing the x-amz-copy-source-if-modified-since and x-amz-copy-source-if-unmodified-since values in the wrong format to the server. Fix has been added to minio.js file to send the correct time format. The unit test also had a sample date in the wrong format, which has also been fixed.

Fixes #620