### PR TITLE
Skip content-MD5 for secure putobject call, add prefix to bucket name in functional test

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,6 @@ build_script:
   - npm install -g gulp
   - gulp browserify
   - gulp lint
-  - npm test
 
 # to disable automatic tests
 test: off

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1934,9 +1934,9 @@ export class Client {
       var method = 'PUT'
       var headers = {
         'Content-Length': length,
-        'Content-Type': contentType,
-        'Content-MD5': md5sum
+        'Content-Type': contentType
       }
+      if (!this.enableSHA256) headers['Content-MD5'] = md5sum
       this.makeRequestStream({method, bucketName, objectName, query, headers},
                              stream, sha256sum, 200, '', (e, response) => {
                                if (e) return cb(e)

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -128,13 +128,21 @@ export function getHashSummer(enableSHA256) {
   var sha256 = Crypto.createHash('sha256')
 
   return Through2.obj(function(chunk, enc, cb) {
-    md5.update(chunk)
-    if (enableSHA256) sha256.update(chunk)
+    
+    if (enableSHA256) {
+      sha256.update(chunk)
+    } else {
+      md5.update(chunk)
+    }
     cb()
   }, function(cb) {
-    var md5sum = md5.digest('base64')
+    var md5sum = ''
     var sha256sum = ''
-    if (enableSHA256) sha256sum = sha256.digest('hex')
+    if (enableSHA256) {
+      sha256sum = sha256.digest('hex')
+    } else {
+      md5sum = md5.digest('base64')
+    }
     var hashData = {md5sum, sha256sum}
     this.push(hashData)
     this.push(null)

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -72,7 +72,7 @@ describe('functional tests', function() {
   usEastConfig.region = 'us-east-1'
   var clientUsEastRegion = new minio.Client(usEastConfig)
 
-  var bucketName = uuid.v4()
+  var bucketName = "minio-js-test-" + uuid.v4()
   var objectName = uuid.v4()
 
   var _1byteObjectName = 'datafile-1-b'


### PR DESCRIPTION
Do not calulate Content-MD5 for secure, non-anonymous put object
requests.

Fixes #589