### PR TITLE
bucketExists: Use a bool to indicate if a bucket exists or not

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -162,7 +162,7 @@ minioClient.listBuckets(function(err, buckets) {
 ```
 
 <a name="bucketExists"></a>
-#### bucketExists(bucketName[, callback])
+#### bucketExists(bucketName, callback)
 
 Checks if a bucket exists.
 
@@ -173,19 +173,19 @@ __Parameters__
 | Param  | Type  | Description  |
 |---|---|---|
 | `bucketName`  |  _string_ | Name of the bucket.  |
-| `callback(err)`  | _function_  | `err` is `null` if the bucket exists. `err.code` is `NoSuchBucket` in case the bucket does not exist. If no callback is passed, a `Promise` is returned. |
+| `callback(err, exists)`  | _function_  | `exists` is a boolean which indicates whether `bucketName` exists or not. `err` is set when an error occurs during the operation. |
 
 __Example__
 
 
 ```js
-minioClient.bucketExists('mybucket', function(err) {
+minioClient.bucketExists('mybucket', function(err, exists) {
   if (err) {
-     if (err.code == 'NoSuchBucket') return console.log("bucket does not exist.")
-     return console.log(err)
+    return console.log(err)
   }
-  // if err is null it indicates that the bucket exists.
-  console.log('Bucket exists.')
+  if (exists) {
+    return console.log('Bucket exists.')
+  }
 })
 ```
 

--- a/examples/bucket-exists.js
+++ b/examples/bucket-exists.js
@@ -26,9 +26,11 @@ var s3Client = new Minio.Client({
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 
-s3Client.bucketExists('my-bucketname', function(e) {
-  if (e) {
-    return console.log(e)
+s3Client.bucketExists('my-bucketname', function(err, exists) {
+  if (err) {
+    return console.log(err)
   }
-  console.log("True")
+  if (exists) {
+      console.log("Bucket exists.")
+  }
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "minio",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "S3 Compatible Cloud Storage client",
   "main": "./dist/main/minio.js",
   "scripts": {

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -647,7 +647,13 @@ export class Client {
       throw new TypeError('callback should be of type "function"')
     }
     var method = 'HEAD'
-    this.makeRequest({method, bucketName}, '', 200, '', false, cb)
+    this.makeRequest({method, bucketName}, '', 200, '', false, err => {
+      if (err) {
+        if (err.code == 'NoSuchBucket' || err.code == 'NotFound') return cb(null, false)
+        return cb(err)
+      }
+      cb(null, true)
+    })
   }
 
   // Remove a bucket.

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -190,8 +190,8 @@ describe('functional tests', function() {
   describe('bucketExists', () => {
     step(`bucketExists(bucketName, cb)_bucketName:${bucketName}_`, done => client.bucketExists(bucketName, done))
     step(`bucketExists(bucketName, cb)_bucketName:${bucketName}random_`, done => {
-      client.bucketExists(bucketName + 'random', (e) => {
-        if (e.code === 'NoSuchBucket') return done()
+      client.bucketExists(bucketName + 'random', (e, exists) => {
+        if (e === null && !exists) return done()
         done(new Error())
       })
     })


### PR DESCRIPTION
This is a breaking API change. bucketExists API will require
a callback with this signature cb(err, bool). This is a better
way to indicate whether a bucket exists or not.

Fixes #648 