### PR TITLE
Connection Agent to inherit options of GlobalAgent

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -117,7 +117,30 @@ export class Client {
     var libraryAgent = `Minio ${libraryComments} minio-js/${Package.version}`
     // User agent block ends.
 
-    this.agent = new transport.Agent({ keepAlive: true })
+    // Look over configuration in Global Agent 
+    //   to copy some of values which defined to
+    //   be reused on base system global agent config
+    //   @link https://nodejs.org/api/https.html#https_https_globalagent
+    var globalAgent = transport.globalAgent;
+    // Currently supported options
+    // - List of CA certificates to trust
+    var caList = [];
+    // Check that Global agent has required chain of options
+    //  Can include following options:
+    //  - https://nodejs.org/api/http.html#http_http_request_options_callback
+    //  - https://nodejs.org/api/tls.html#tls_tls_createsecurecontext_options
+    //  However proper set of options which should be inherited is TBD
+    if(globalAgent.hasOwnProperty("options")) {
+      // Check CA rules
+      if(globalAgent.options.hasOwnProperty("ca")) {
+        // Check that CA rules is actual type of Array or String
+        if(globalAgent.options.ca.hasOwnProperty("length")) {
+          caList = globalAgent.options.ca; 
+        }
+      }
+    }
+    
+    this.agent = new transport.Agent({ keepAlive: true, ca: caList })
     this.transport = transport
     this.host = host
     this.port = port


### PR DESCRIPTION
As some of options can be vital for SSL connections in some of environments, and those can be set up at the level of software global configuration including outgoing requests custom trust certificates there should be defined mechanics which will allow transport.Agent created on instantiation of Minio-JS to inherit some of the options which can be considered as safe to pass down to new Agent or simply to be shared across whole system connectivity components.

One of this kind of options is CA trust certificates which should be able to be preloaded to GlobalAgent at any point of software startup and prior instantiation of Minio-JS.

Code proposal allows to check such options defined at a Global Agent instance and derive them to new transport for connect to Minio servers which having some custom certificates installed.