### PR TITLE
Move source-map-support package to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "mime-types": "^2.1.14",
     "mkdirp": "^0.5.1",
     "querystring": "0.2.0",
-    "source-map-support": "^0.4.12",
     "through2": "^0.6.5",
     "uuid": "^3.1.0",
     "xml": "^1.0.0",
@@ -59,6 +58,7 @@
     "mocha-steps": "^1.1.0",
     "nock": "^2.12.0",
     "rewire": "^2.3.3",
+    "source-map-support": "^0.4.12",
     "superagent": "^1.8.5"
   },
   "keywords": [


### PR DESCRIPTION
Move source-map-support to devDependencies so that this
package doesn't get instaleld in production.

Refer: https://github.com/minio/minio-js/pull/710#issuecomment-404276845