### PR TITLE
fix error not thrown when secure param is passed

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -51,7 +51,7 @@ var Package = require('../../package.json')
 
 export class Client {
   constructor(params) {
-    if (params.secure) throw new Error('"secure" option deprecated, "useSSL" should be used instead')
+    if (typeof params.secure !== 'undefined') throw new Error('"secure" option deprecated, "useSSL" should be used instead')
     // Default values if not specified.
     if (typeof params.useSSL === 'undefined') params.useSSL = true
     if (!params.port) params.port = 0

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -199,6 +199,32 @@ describe('Client', function() {
         done()
       }
     })
+    it('should fail when secure param is passed', (done) => {
+      try {
+        new Minio.Client({
+          endPoint: 'localhost',
+          secure: false,
+          port: 9000,
+          accessKey: 'accesskey',
+          secretKey: 'secretkey'
+        })
+      } catch (e) {
+        done()
+      }
+    })
+    it('should fail when secure param is passed', (done) => {
+      try {
+        new Minio.Client({
+          endPoint: 'localhost',
+          secure: true,
+          port: 9000,
+          accessKey: 'accesskey',
+          secretKey: 'secretkey'
+        })
+      } catch (e) {
+        done()
+      }
+    })
   })
   describe('Presigned URL', () => {
     describe('presigned-get', () => {


### PR DESCRIPTION
When the Client is initialized with option `secure: false` or `secure: true`, an error should be thrown stating secure option is deprecated.