### PR TITLE
Add requestDate parameter to presignedUrl() and presignedGetObject()

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ script:
 - gulp lint
 
 before_install:
-- npm i -g yarn
+- npm i -g yarn@1.9.4
 
 install:
 - yarn

--- a/docs/API.md
+++ b/docs/API.md
@@ -702,7 +702,7 @@ minioClient.removeIncompleteUpload('mybucket', 'photo.jpg', function(err) {
 Presigned URLs are generated for temporary download/upload access to private objects.
 
 <a name="presignedUrl"></a>
-### presignedUrl(httpMethod, bucketName, objectName, expiry[, reqParams, requestDate, cb])
+### presignedUrl(httpMethod, bucketName, objectName[, expiry, reqParams, requestDate, cb])
 
 Generates a presigned URL for the provided HTTP method, 'httpMethod'. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which the URL is no longer valid. The default value is 7 days.
 
@@ -715,9 +715,9 @@ __Parameters__
 |---|---|---|
 |`bucketName` | _string_ | Name of the bucket. |
 |`objectName` | _string_ | Name of the object. |
-|`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. |
-|`reqParams`  | _object_ | request parameters. |
-|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. |
+|`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. (optional) |
+|`reqParams`  | _object_ | request parameters. (optional) |
+|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. (optional) |
 |`callback(err, presignedUrl)` | _function_ | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 
@@ -748,7 +748,7 @@ minioClient.presignedUrl('GET', 'mybucket', '', 1000, {'prefix': 'data', 'max-ke
 ```
 
 <a name="presignedGetObject"></a>
-### presignedGetObject(bucketName, objectName, expiry[, cb])
+### presignedGetObject(bucketName, objectName[, expiry, respHeaders, requestDate, cb])
 
 Generates a presigned URL for HTTP GET operations. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which the URL is no longer valid. The default value is 7 days.
 
@@ -761,9 +761,9 @@ __Parameters__
 |---|---|---|
 |`bucketName` | _string_ | Name of the bucket. |
 |`objectName` | _string_ | Name of the object. |
-|`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. |
+|`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. (optional) |
 |`respHeaders`  | _object_ | response headers to override (optional) |
-|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. |
+|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. (optional) |
 |`callback(err, presignedUrl)` | _function_ | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -702,7 +702,7 @@ minioClient.removeIncompleteUpload('mybucket', 'photo.jpg', function(err) {
 Presigned URLs are generated for temporary download/upload access to private objects.
 
 <a name="presignedUrl"></a>
-### presignedUrl(httpMethod, bucketName, objectName, expiry[, reqParams, cb])
+### presignedUrl(httpMethod, bucketName, objectName, expiry[, reqParams, requestDate, cb])
 
 Generates a presigned URL for the provided HTTP method, 'httpMethod'. Browsers/Mobile clients may point to this URL to directly download objects even if the bucket is private. This presigned URL can have an associated expiration time in seconds after which the URL is no longer valid. The default value is 7 days.
 
@@ -717,6 +717,7 @@ __Parameters__
 |`objectName` | _string_ | Name of the object. |
 |`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. |
 |`reqParams`  | _object_ | request parameters. |
+|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. |
 |`callback(err, presignedUrl)` | _function_ | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 
@@ -761,6 +762,8 @@ __Parameters__
 |`bucketName` | _string_ | Name of the bucket. |
 |`objectName` | _string_ | Name of the object. |
 |`expiry`     | _number_ | Expiry time in seconds. Default value is 7 days. |
+|`respHeaders`  | _object_ | response headers to override (optional) |
+|`requestDate`  | _Date_ | A date object, the url will be issued at. Default value is now. |
 |`callback(err, presignedUrl)` | _function_ | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 

--- a/examples/presigned-getobject-request-date.js
+++ b/examples/presigned-getobject-request-date.js
@@ -28,7 +28,7 @@ var s3Client = new Minio.Client({
 
 // Presigned get object URL for my-objectname at my-bucketname, it expires in 7 days by default.
 var requestDate = new Date('2017-01-01');
-var presignedUrl = s3Client.presignedGetObject('my-bucketname', 'my-objectname', 1000, requestDate, function(e, presignedUrl) {
+var presignedUrl = s3Client.presignedGetObject('my-bucketname', 'my-objectname', 1000, {}, requestDate, function(e, presignedUrl) {
   if (e) return console.log(e)
   console.log(presignedUrl)
 })

--- a/examples/presigned-getobject-request-date.js
+++ b/examples/presigned-getobject-request-date.js
@@ -1,0 +1,34 @@
+/*
+ * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+ // Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-objectname
+ // are dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY',
+  useSSL: true // Default is true.
+})
+
+// Presigned get object URL for my-objectname at my-bucketname, it expires in 7 days by default.
+var requestDate = new Date('2017-01-01');
+var presignedUrl = s3Client.presignedGetObject('my-bucketname', 'my-objectname', 1000, requestDate, function(e, presignedUrl) {
+  if (e) return console.log(e)
+  console.log(presignedUrl)
+})

--- a/examples/presigned-getobject-request-date.js
+++ b/examples/presigned-getobject-request-date.js
@@ -15,7 +15,7 @@
  */
 
  // Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and my-objectname
- // are dummy values, please replace them with original values.
+ // are dummy values, please replace them with original values. 
 
 var Minio = require('minio')
 

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -244,6 +244,11 @@ export function isArray(arg) {
   return Array.isArray(arg)
 }
 
+// check if arg is a valid date
+export function isValidDate(arg) {
+  return arg instanceof Date && !isNaN(arg)
+}
+
 // Create a Date string with format:
 // 'YYYYMMDDTHHmmss' + Z
 export function makeDateLong(date) {

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -751,6 +751,31 @@ describe('functional tests', function() {
       })
     })
 
+    step(`presignedUrl(httpMethod, bucketName, objectName, expires, cb)_httpMethod:GET, bucketName:${bucketName}, objectName:${_1byteObjectName}, expires:86400, requestDate:StartOfDay_`, done => {
+      var requestDate = new Date()
+      requestDate.setHours(0,0,0,0)
+      client.presignedUrl('GET', bucketName, _1byteObjectName, 86400, requestDate, (e, presignedUrl) => {
+        if (e) return done(e)
+        var transport = http
+        var options = _.pick(url.parse(presignedUrl), ['hostname', 'port', 'path', 'protocol'])
+        options.method = 'GET'
+        if (options.protocol === 'https:') transport = https
+        var request = transport.request(options, (response) => {
+          if (response.statusCode !== 200) return done(new Error(`error on put : ${response.statusCode}`))
+          var error = null
+          response.on('error', e => done(e))
+          response.on('end', () => done(error))
+          response.on('data', (data) => {
+            if (data.toString() !== _1byte.toString()) {
+              error = new Error('content mismatch')
+            }
+          })
+        })
+        request.on('error', e => done(e))
+        request.end()
+      })
+    })
+
     step(`presignedGetObject(bucketName, objectName, cb)_bucketName:${bucketName}, objectName:${_1byteObjectName}_`, done => {
       client.presignedGetObject(bucketName, _1byteObjectName, (e, presignedUrl) => {
         if (e) return done(e)
@@ -817,6 +842,31 @@ describe('functional tests', function() {
           }
           response.on('data', () => {})
           done()
+        })
+        request.on('error', e => done(e))
+        request.end()
+      })
+    })
+
+    step(`presignedGetObject(bucketName, objectName, cb)_bucketName:${bucketName}, objectName:${_1byteObjectName}, expires:86400, requestDate:StartOfDay_`, done => {
+      var requestDate = new Date()
+      requestDate.setHours(0,0,0,0)
+      client.presignedGetObject(bucketName, _1byteObjectName, 86400, {}, requestDate, (e, presignedUrl) => {
+        if (e) return done(e)
+        var transport = http
+        var options = _.pick(url.parse(presignedUrl), ['hostname', 'port', 'path', 'protocol'])
+        options.method = 'GET'
+        if (options.protocol === 'https:') transport = https
+        var request = transport.request(options, (response) => {
+          if (response.statusCode !== 200) return done(new Error(`error on put : ${response.statusCode}`))
+          var error = null
+          response.on('error', e => done(e))
+          response.on('end', () => done(error))
+          response.on('data', (data) => {
+            if (data.toString() !== _1byte.toString()) {
+              error = new Error('content mismatch')
+            }
+          })
         })
         request.on('error', e => done(e))
         request.end()


### PR DESCRIPTION
Hi there,

I just added a parameter `requestDate` to the methods `presignedUrl()` and `presignedGetObject()`.

Please have a look at #724 for more details.

My todo checklist:

- [x] Adjust the code
- [x] Add js-doc parameter description
- [x] Create new tests for the functionality
- [x] All (old and new) tests should pass
- [x] Update docs
- [x] Create example