### PR TITLE
Add parameter start-after to ListObjectsV2

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -247,7 +247,7 @@ stream.on('error', function(err) { console.log(err) } )
 ```
 
 <a name="listObjectsV2"></a>
-### listObjectsV2(bucketName, prefix, recursive)
+### listObjectsV2(bucketName, prefix, recursive, startAfter)
 
 Lists all objects in a bucket using S3 listing objects V2 API
 
@@ -259,6 +259,7 @@ __Parameters__
 | `bucketName` | _string_ | Name of the bucket. |
 | `prefix`  | _string_  |  The prefix of the objects that should be listed (optional, default `''`). |
 | `recursive`  | _bool_  | `true` indicates recursive style listing and `false` indicates directory style listing delimited by '/'. (optional, default `false`).  |
+| `startAfter`  | _string_  |  Specifies the object name to start after when listing objects in a bucket. (optional, default `''`). |
 
 
 __Return Value__
@@ -282,7 +283,7 @@ __Example__
 
 
 ```js
-var stream = minioClient.listObjectsV2('mybucket','', true)
+var stream = minioClient.listObjectsV2('mybucket','', true,'')
 stream.on('data', function(obj) { console.log(obj) } )
 stream.on('error', function(err) { console.log(err) } )
 ```

--- a/examples/list-objects-v2.js
+++ b/examples/list-objects-v2.js
@@ -25,7 +25,7 @@ var s3Client = new Minio.Client({
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 // List all object paths in bucket my-bucketname.
-var objectsStream = s3Client.listObjectsV2('my-bucketname', '', true)
+var objectsStream = s3Client.listObjectsV2('my-bucketname', '', true,'')
 objectsStream.on('data', function(obj) {
   console.log(obj)
 })

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -958,9 +958,9 @@ describe('functional tests', function() {
         })
     })
 
-    step(`listObjectsV2(bucketName, prefix, recursive)_bucketName:${bucketName}, recursive:true_`, done => {
+    step(`listObjectsV2(bucketName, prefix, recursive, startAfter)_bucketName:${bucketName}, recursive:true_`, done => {
       listArray = []
-      client.listObjectsV2(bucketName, '', true)
+      client.listObjectsV2(bucketName, '', true,'')
         .on('error', done)
         .on('end', () => {
           if (_.isEqual(objArray, listArray)) return done()


### PR DESCRIPTION
Add parameter start-after to ListObjectsV2 to make the iteration uninterruptible. 

Resolves the [issue](https://github.com/minio/minio-js/issues/733)