### PR TITLE
fix hardcoded region value for listBuckets function

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -556,7 +556,8 @@ export class Client {
       throw new TypeError('callback should be of type "function"')
     }
     var method = 'GET'
-    this.makeRequest({method}, '', 200, 'us-east-1', true, (e, response) => {
+    var region = this.region != null ? this.region : 'us-east-1';
+    this.makeRequest({method}, '', 200, region, true, (e, response) => {
       if (e) return cb(e)
       var transformer = transformers.getListBucketTransformer()
       var buckets


### PR DESCRIPTION
This commits fixes the hardcoded value of the region in 'listBuckets'
function. This bug causes a signature error on other zones than
us-east-1 or on other s3 providers.