### PR TITLE
Set prefix, delimiter params even when empty

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1144,20 +1144,17 @@ export class Client {
     if (!isNumber(maxKeys)) {
       throw new TypeError('maxKeys should be of type "number"')
     }
+
     var queries = []
     // escape every value in query string, except maxKeys
-    if (prefix) {
-      prefix = uriEscape(prefix)
-      queries.push(`prefix=${prefix}`)
-    }
+    queries.push(`prefix=${uriEscape(prefix)}`)
+    queries.push(`delimiter=${uriEscape(delimiter)}`)
+
     if (marker) {
       marker = uriEscape(marker)
       queries.push(`marker=${marker}`)
     }
-    if (delimiter) {
-      delimiter = uriEscape(delimiter)
-      queries.push(`delimiter=${delimiter}`)
-    }
+
     // no need to escape maxKeys
     if (maxKeys) {
       if (maxKeys >= 1000) {
@@ -1273,17 +1270,12 @@ export class Client {
     queries.push(`list-type=2`)
 
     // escape every value in query string, except maxKeys
-    if (prefix) {
-      prefix = uriEscape(prefix)
-      queries.push(`prefix=${prefix}`)
-    }
+    queries.push(`prefix=${uriEscape(prefix)}`)
+    queries.push(`delimiter=${uriEscape(delimiter)}`)
+
     if (continuationToken) {
       continuationToken = uriEscape(continuationToken)
       queries.push(`continuation-token=${continuationToken}`)
-    }
-    if (delimiter) {
-      delimiter = uriEscape(delimiter)
-      queries.push(`delimiter=${delimiter}`)
     }
     // Set start-after
     if (startAfter) {
@@ -1296,7 +1288,7 @@ export class Client {
         maxKeys = 1000
       }
       queries.push(`max-keys=${maxKeys}`)
-    }    
+    }
     queries.sort()
     var query = ''
     if (queries.length > 0) {
@@ -1491,7 +1483,7 @@ export class Client {
       })
     }, cb)
   }
-     
+
 
   // Get the policy on a bucket or an object prefix.
   //
@@ -1878,9 +1870,9 @@ export class Client {
       throw new TypeError('delimiter should be of type "string"')
     }
     var queries = []
-    if (prefix) {
-      queries.push(`prefix=${uriEscape(prefix)}`)
-    }
+    queries.push(`prefix=${uriEscape(prefix)}`)
+    queries.push(`delimiter=${uriEscape(delimiter)}`)
+
     if (keyMarker) {
       keyMarker = uriEscape(keyMarker)
       queries.push(`key-marker=${keyMarker}`)
@@ -1888,9 +1880,7 @@ export class Client {
     if (uploadIdMarker) {
       queries.push(`upload-id-marker=${uploadIdMarker}`)
     }
-    if (delimiter) {
-      queries.push(`delimiter=${uriEscape(delimiter)}`)
-    }
+
     var maxUploads = 1000
     queries.push(`max-uploads=${maxUploads}`)
     queries.sort()


### PR DESCRIPTION
We have never set values which are empty on the request
because they are perhaps not useful in the List query,
but this assumption is wrong when there are restricted
policies for a given user, because empty is actually
a valid value in IAM or Bucket policy conditions.

For example following condition would never work with our
ListObjects call and AWS cli would work fine.

            "Condition": {
                "StringEquals": {
                    "s3:prefix": [
                        "",
                        "data/",
                        "data"
                    ],
                    "s3:delimiter": [
                        "/",
                        ""
                    ]
                }
            }

The reason is empty or not prefix and delimiter should be
added to the query param in List operation, such that server
can use the value to validate the policies for the incoming
request.

Refer minio/minio-go#1064