### PR TITLE
Fix broken link to the shopping app example

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,7 +201,7 @@ The full API Reference is available here.
 ## Explore Further
 * [Complete Documentation](https://docs.minio.io)
 * [Minio JavaScript Client SDK API Reference](https://docs.minio.io/docs/javascript-client-api-reference)
-* [Build your own Shopping App Example- Full Application Example ](https://docs.minio.io/docs/javascript-shopping-app)
+* [Build your own Shopping App Example- Full Application Example ](https://github.com/minio/minio-js-store-app)
 
 ## Contribute
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -192,7 +192,7 @@ mc ls play/europetrip/
 ## 了解更多
 * [完整文档](https://docs.minio.io)
 * [Minio JavaScript Client SDK API文档](https://docs.minio.io/docs/javascript-client-api-reference)
-* [创建属于你的购物APP-完整示例](https://docs.minio.io/docs/javascript-shopping-app)
+* [创建属于你的购物APP-完整示例](https://github.com/minio/minio-js-store-app)
 
 ## 贡献
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1065,4 +1065,4 @@ minioClient.setRequestOptions({rejectUnauthorized: false})
 ## 7. Explore Further
 
 
-- [Build your own Shopping App Example](https://docs.minio.io/docs/javascript-shopping-app)
+- [Build your own Shopping App Example](https://github.com/minio/minio-js-store-app)

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -1002,4 +1002,4 @@ minioClient.setBucketPolicy('my-bucketname', 'img-', minio.Policy.READONLY, func
 ## 6. 了解更多
 
 
-- [创建属于你的购物APP示例](https://docs.minio.io/docs/javascript-shopping-app)
+- [创建属于你的购物APP示例](https://github.com/minio/minio-js-store-app)


### PR DESCRIPTION
Link to shopping app example was broken.  It was pointing to a non-existent link in docs.minio.io. Pointed it to it's repo in github.

Fixes #755