### PR TITLE
Replaces Minio refs with MinIO and minio.io links with min.io

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ### Setup your minio-js Github Repository
 Fork [minio-js upstream](https://github.com/minio/minio-js/fork) source repository to your own personal repository.
 
-Minio Javascript library uses gulp for its dependency management http://gulpjs.com/
+MinIO Javascript library uses gulp for its dependency management http://gulpjs.com/
 
 ```bash
 $ git clone https://github.com/$USER_ID/minio-js

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -1,5 +1,5 @@
 # For maintainers only
-Minio JS SDK uses [npm4+](https://www.npmjs.org/) build system.
+MinIO JS SDK uses [npm4+](https://www.npmjs.org/) build system.
 
 ## Responsibilities
 Go through [Maintainer Responsibility Guide](https://gist.github.com/abperiasamy/f4d9b31d3186bbd26522).
@@ -40,7 +40,7 @@ $ npm publish
 ```
 
 ### Tag
-Tag and sign your release commit, additionally this step requires you to have access to Minio's trusted private key.
+Tag and sign your release commit, additionally this step requires you to have access to MinIO's trusted private key.
 ```
 $ export GNUPGHOME=/media/${USER}/minio/trusted
 $ git tag -s 3.2.1

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-# Minio JavaScript Library for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# MinIO JavaScript Library for Amazon S3 Compatible Cloud Storage [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 [![NPM](https://nodei.co/npm/minio.png)](https://nodei.co/npm/minio/)
 
-The Minio JavaScript Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
+The MinIO JavaScript Client SDK provides simple APIs to access any Amazon S3 compatible object storage server.
 
-This quickstart guide will show you how to install the client SDK and execute an example JavaScript program. For a complete list of APIs and examples, please take a look at the [JavaScript Client API Reference](https://docs.minio.io/docs/javascript-client-api-reference) documentation.
+This quickstart guide will show you how to install the client SDK and execute an example JavaScript program. For a complete list of APIs and examples, please take a look at the [JavaScript Client API Reference](https://docs.min.io/docs/javascript-client-api-reference) documentation.
 
 This document assumes that you have a working [nodejs](http://nodejs.org/) setup in place.
 
@@ -30,9 +30,9 @@ npm install -g
 npm install --save-dev @types/minio
 ```
 
-## Initialize Minio Client
+## Initialize MinIO Client
 
-You need five items in order to connect to Minio object storage server.
+You need five items in order to connect to MinIO object storage server.
 
 
 | Params     | Description |
@@ -60,7 +60,7 @@ var minioClient = new Minio.Client({
 
 This example program connects to an object storage server, makes a bucket on the server and then uploads a file to the bucket.
 
-We will use the Minio server running at [https://play.minio.io:9000](https://play.minio.io:9000) in this example. Feel free to use this service for testing and development. Access credentials shown in this example are open to the public.
+We will use the MinIO server running at [https://play.min.io:9000](https://play.min.io:9000) in this example. Feel free to use this service for testing and development. Access credentials shown in this example are open to the public.
 
 #### file-uploader.js
 
@@ -113,49 +113,49 @@ mc ls play/europetrip/
 
 The full API Reference is available here.
 
-* [Complete API Reference](https://docs.minio.io/docs/javascript-client-api-reference)
+* [Complete API Reference](https://docs.min.io/docs/javascript-client-api-reference)
 
 ### API Reference : Bucket Operations
 
-* [`makeBucket`](https://docs.minio.io/docs/javascript-client-api-reference#makeBucket)
-* [`listBuckets`](https://docs.minio.io/docs/javascript-client-api-reference#listBuckets)
-* [`bucketExists`](https://docs.minio.io/docs/javascript-client-api-reference#bucketExists)
-* [`removeBucket`](https://docs.minio.io/docs/javascript-client-api-reference#removeBucket)
-* [`listObjects`](https://docs.minio.io/docs/javascript-client-api-reference#listObjects)
-* [`listObjectsV2`](https://docs.minio.io/docs/javascript-client-api-reference#listObjectsV2)
-* [`listIncompleteUploads`](https://docs.minio.io/docs/javascript-client-api-reference#listIncompleteUploads)
+* [`makeBucket`](https://docs.min.io/docs/javascript-client-api-reference#makeBucket)
+* [`listBuckets`](https://docs.min.io/docs/javascript-client-api-reference#listBuckets)
+* [`bucketExists`](https://docs.min.io/docs/javascript-client-api-reference#bucketExists)
+* [`removeBucket`](https://docs.min.io/docs/javascript-client-api-reference#removeBucket)
+* [`listObjects`](https://docs.min.io/docs/javascript-client-api-reference#listObjects)
+* [`listObjectsV2`](https://docs.min.io/docs/javascript-client-api-reference#listObjectsV2)
+* [`listIncompleteUploads`](https://docs.min.io/docs/javascript-client-api-reference#listIncompleteUploads)
 
 ### API Reference : File Object Operations
 
-* [`fPutObject`](https://docs.minio.io/docs/javascript-client-api-reference#fPutObject)
-* [`fGetObject`](https://docs.minio.io/docs/javascript-client-api-reference#fGetObject)
+* [`fPutObject`](https://docs.min.io/docs/javascript-client-api-reference#fPutObject)
+* [`fGetObject`](https://docs.min.io/docs/javascript-client-api-reference#fGetObject)
 
 ### API Reference : Object Operations
 
-* [`getObject`](https://docs.minio.io/docs/javascript-client-api-reference#getObject)
-* [`putObject`](https://docs.minio.io/docs/javascript-client-api-reference#putObject)
-* [`copyObject`](https://docs.minio.io/docs/javascript-client-api-reference#copyObject)
-* [`statObject`](https://docs.minio.io/docs/javascript-client-api-reference#statObject)
-* [`removeObject`](https://docs.minio.io/docs/javascript-client-api-reference#removeObject)
-* [`removeIncompleteUpload`](https://docs.minio.io/docs/javascript-client-api-reference#removeIncompleteUpload)
+* [`getObject`](https://docs.min.io/docs/javascript-client-api-reference#getObject)
+* [`putObject`](https://docs.min.io/docs/javascript-client-api-reference#putObject)
+* [`copyObject`](https://docs.min.io/docs/javascript-client-api-reference#copyObject)
+* [`statObject`](https://docs.min.io/docs/javascript-client-api-reference#statObject)
+* [`removeObject`](https://docs.min.io/docs/javascript-client-api-reference#removeObject)
+* [`removeIncompleteUpload`](https://docs.min.io/docs/javascript-client-api-reference#removeIncompleteUpload)
 
 ### API Reference : Presigned Operations
 
-* [`presignedGetObject`](https://docs.minio.io/docs/javascript-client-api-reference#presignedGetObject)
-* [`presignedPutObject`](https://docs.minio.io/docs/javascript-client-api-reference#presignedPutObject)
-* [`presignedPostPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#presignedPostPolicy)
+* [`presignedGetObject`](https://docs.min.io/docs/javascript-client-api-reference#presignedGetObject)
+* [`presignedPutObject`](https://docs.min.io/docs/javascript-client-api-reference#presignedPutObject)
+* [`presignedPostPolicy`](https://docs.min.io/docs/javascript-client-api-reference#presignedPostPolicy)
 
 ### API Reference : Bucket Notification Operations
 
-* [`getBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#getBucketNotification)
-* [`setBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#setBucketNotification)
-* [`removeAllBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#removeAllBucketNotification)
-* [`listenBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#listenBucketNotification) (Minio Extension)
+* [`getBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#getBucketNotification)
+* [`setBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#setBucketNotification)
+* [`removeAllBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#removeAllBucketNotification)
+* [`listenBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#listenBucketNotification) (MinIO Extension)
 
 ### API Reference : Bucket Policy Operations
 
-* [`getBucketPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#getBucketPolicy)
-* [`setBucketPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#setBucketPolicy)
+* [`getBucketPolicy`](https://docs.min.io/docs/javascript-client-api-reference#getBucketPolicy)
+* [`setBucketPolicy`](https://docs.min.io/docs/javascript-client-api-reference#setBucketPolicy)
 
 
 ## Full Examples
@@ -192,15 +192,15 @@ The full API Reference is available here.
 * [get-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-notification.js)
 * [set-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-notification.js)
 * [remove-all-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/remove-all-bucket-notification.js)
-* [listen-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/minio/listen-bucket-notification.js) (Minio Extension)
+* [listen-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/minio/listen-bucket-notification.js) (MinIO Extension)
 
 #### Full Examples: Bucket Policy Operations
 * [get-bucket-policy.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-policy.js)
 * [set-bucket-policy.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-policy.js)
 
 ## Explore Further
-* [Complete Documentation](https://docs.minio.io)
-* [Minio JavaScript Client SDK API Reference](https://docs.minio.io/docs/javascript-client-api-reference)
+* [Complete Documentation](https://docs.min.io)
+* [MinIO JavaScript Client SDK API Reference](https://docs.min.io/docs/javascript-client-api-reference)
 * [Build your own Shopping App Example- Full Application Example ](https://github.com/minio/minio-js-store-app)
 
 ## Contribute

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -1,10 +1,10 @@
-# 适用于Amazon S3兼容云存储的Minio JavaScript Library [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# 适用于Amazon S3兼容云存储的Minio JavaScript Library [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 [![NPM](https://nodei.co/npm/minio.png)](https://nodei.co/npm/minio/)
 
-Minio JavaScript Client SDK提供简单的API来访问任何Amazon S3兼容的对象存储服务。
+MinIO JavaScript Client SDK提供简单的API来访问任何Amazon S3兼容的对象存储服务。
 
-本快速入门指南将向您展示如何安装客户端SDK并执行示例JavaScript程序。有关API和示例的完整列表，请参阅[JavaScript客户端API参考](https://docs.minio.io/docs/javascript-client-api-reference)文档。
+本快速入门指南将向您展示如何安装客户端SDK并执行示例JavaScript程序。有关API和示例的完整列表，请参阅[JavaScript客户端API参考](https://docs.min.io/docs/javascript-client-api-reference)文档。
 
 本文假设你已经安装了[nodejs](http://nodejs.org/) 。
 
@@ -52,7 +52,7 @@ var minioClient = new Minio.Client({
 
 本示例连接到一个对象存储服务，创建一个存储桶并上传一个文件到存储桶中。
 
-我们在本示例中使用运行在 [https://play.minio.io:9000](https://play.minio.io:9000) 上的Minio服务，你可以用这个服务来开发和测试。示例中的访问凭据是公开的。
+我们在本示例中使用运行在 [https://play.min.io:9000](https://play.min.io:9000) 上的Minio服务，你可以用这个服务来开发和测试。示例中的访问凭据是公开的。
 
 #### file-uploader.js
 
@@ -104,49 +104,49 @@ mc ls play/europetrip/
 ## API文档
 
 完整的API文档在这里。
-* [完整API文档](https://docs.minio.io/docs/javascript-client-api-reference)
+* [完整API文档](https://docs.min.io/docs/javascript-client-api-reference)
 
 ### API文档 : 操作存储桶
 
-* [`makeBucket`](https://docs.minio.io/docs/javascript-client-api-reference#makeBucket)
-* [`listBuckets`](https://docs.minio.io/docs/javascript-client-api-reference#listBuckets)
-* [`bucketExists`](https://docs.minio.io/docs/javascript-client-api-reference#bucketExists)
-* [`removeBucket`](https://docs.minio.io/docs/javascript-client-api-reference#removeBucket)
-* [`listObjects`](https://docs.minio.io/docs/javascript-client-api-reference#listObjects)
-* [`listObjectsV2`](https://docs.minio.io/docs/javascript-client-api-reference#listObjectsV2)
-* [`listIncompleteUploads`](https://docs.minio.io/docs/javascript-client-api-reference#listIncompleteUploads)
+* [`makeBucket`](https://docs.min.io/docs/javascript-client-api-reference#makeBucket)
+* [`listBuckets`](https://docs.min.io/docs/javascript-client-api-reference#listBuckets)
+* [`bucketExists`](https://docs.min.io/docs/javascript-client-api-reference#bucketExists)
+* [`removeBucket`](https://docs.min.io/docs/javascript-client-api-reference#removeBucket)
+* [`listObjects`](https://docs.min.io/docs/javascript-client-api-reference#listObjects)
+* [`listObjectsV2`](https://docs.min.io/docs/javascript-client-api-reference#listObjectsV2)
+* [`listIncompleteUploads`](https://docs.min.io/docs/javascript-client-api-reference#listIncompleteUploads)
 
 ### API文档 : 操作文件对象
 
-* [`fPutObject`](https://docs.minio.io/docs/javascript-client-api-reference#fPutObject)
-* [`fGetObject`](https://docs.minio.io/docs/javascript-client-api-reference#fGetObject)
+* [`fPutObject`](https://docs.min.io/docs/javascript-client-api-reference#fPutObject)
+* [`fGetObject`](https://docs.min.io/docs/javascript-client-api-reference#fGetObject)
 
 ### API文档 : 操作对象
 
-* [`getObject`](https://docs.minio.io/docs/javascript-client-api-reference#getObject)
-* [`putObject`](https://docs.minio.io/docs/javascript-client-api-reference#putObject)
-* [`copyObject`](https://docs.minio.io/docs/javascript-client-api-reference#copyObject)
-* [`statObject`](https://docs.minio.io/docs/javascript-client-api-reference#statObject)
-* [`removeObject`](https://docs.minio.io/docs/javascript-client-api-reference#removeObject)
-* [`removeIncompleteUpload`](https://docs.minio.io/docs/javascript-client-api-reference#removeIncompleteUpload)
+* [`getObject`](https://docs.min.io/docs/javascript-client-api-reference#getObject)
+* [`putObject`](https://docs.min.io/docs/javascript-client-api-reference#putObject)
+* [`copyObject`](https://docs.min.io/docs/javascript-client-api-reference#copyObject)
+* [`statObject`](https://docs.min.io/docs/javascript-client-api-reference#statObject)
+* [`removeObject`](https://docs.min.io/docs/javascript-client-api-reference#removeObject)
+* [`removeIncompleteUpload`](https://docs.min.io/docs/javascript-client-api-reference#removeIncompleteUpload)
 
 ### API文档 :  Presigned操作
 
-* [`presignedGetObject`](https://docs.minio.io/docs/javascript-client-api-reference#presignedGetObject)
-* [`presignedPutObject`](https://docs.minio.io/docs/javascript-client-api-reference#presignedPutObject)
-* [`presignedPostPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#presignedPostPolicy)
+* [`presignedGetObject`](https://docs.min.io/docs/javascript-client-api-reference#presignedGetObject)
+* [`presignedPutObject`](https://docs.min.io/docs/javascript-client-api-reference#presignedPutObject)
+* [`presignedPostPolicy`](https://docs.min.io/docs/javascript-client-api-reference#presignedPostPolicy)
 
 ### API文档 : 存储桶通知
 
-* [`getBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#getBucketNotification)
-* [`setBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#setBucketNotification)
-* [`removeAllBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#removeAllBucketNotification)
-* [`listenBucketNotification`](https://docs.minio.io/docs/javascript-client-api-reference#listenBucketNotification) (Minio Extension)
+* [`getBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#getBucketNotification)
+* [`setBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#setBucketNotification)
+* [`removeAllBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#removeAllBucketNotification)
+* [`listenBucketNotification`](https://docs.min.io/docs/javascript-client-api-reference#listenBucketNotification) (MinIO Extension)
 
 ### API文档 : 存储桶策略
 
-* [`getBucketPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#getBucketPolicy)
-* [`setBucketPolicy`](https://docs.minio.io/docs/javascript-client-api-reference#setBucketPolicy)
+* [`getBucketPolicy`](https://docs.min.io/docs/javascript-client-api-reference#getBucketPolicy)
+* [`setBucketPolicy`](https://docs.min.io/docs/javascript-client-api-reference#setBucketPolicy)
 
 
 ## 完整示例
@@ -183,15 +183,15 @@ mc ls play/europetrip/
 * [get-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-notification.js)
 * [set-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-notification.js)
 * [remove-all-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/remove-all-bucket-notification.js)
-* [listen-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/minio/listen-bucket-notification.js) (Minio Extension)
+* [listen-bucket-notification.js](https://github.com/minio/minio-js/blob/master/examples/minio/listen-bucket-notification.js) (MinIO Extension)
 
 #### 完整示例 : 存储桶策略
 * [get-bucket-policy.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-policy.js)
 * [set-bucket-policy.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-policy.js)
 
 ## 了解更多
-* [完整文档](https://docs.minio.io)
-* [Minio JavaScript Client SDK API文档](https://docs.minio.io/docs/javascript-client-api-reference)
+* [完整文档](https://docs.min.io)
+* [MinIO JavaScript Client SDK API文档](https://docs.min.io/docs/javascript-client-api-reference)
 * [创建属于你的购物APP-完整示例](https://github.com/minio/minio-js-store-app)
 
 ## 贡献

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,8 +1,8 @@
-# JavaScript Client API Reference [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# JavaScript Client API Reference [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
-## Initialize Minio Client object.
+## Initialize MinIO Client object.
 
-## Minio
+## MinIO
 
 ```js
 var Minio = require('minio')
@@ -68,7 +68,7 @@ __Parameters__
 
 __Example__
 
-## Create client for Minio
+## Create client for MinIO
 
 ```js
 var Minio = require('minio')
@@ -975,7 +975,7 @@ minioClient.removeAllBucketNotification('my-bucketname', function(e) {
 
 Listen for notifications on a bucket. Additionally one can provider
 filters for prefix, suffix and events. There is no prior set bucket notification
-needed to use this API. This is an Minio extension API where unique identifiers
+needed to use this API. This is an MinIO extension API where unique identifiers
 are regitered and unregistered by the server automatically based on incoming requests.
 
 Returns an `EventEmitter`, which will emit a `notification` event carrying the record.

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -1,8 +1,8 @@
-# JavaScript Client API参考文档 [![Slack](https://slack.minio.io/slack?type=svg)](https://slack.minio.io)
+# JavaScript Client API参考文档 [![Slack](https://slack.min.io/slack?type=svg)](https://slack.min.io)
 
 ## 初使化Minio Client object.
 
-## Minio
+## MinIO
 
 ```js
 var Minio = require('minio')

--- a/docs/zh_CN/CONTRIBUTING.md
+++ b/docs/zh_CN/CONTRIBUTING.md
@@ -1,7 +1,7 @@
 ### 设置你的minio-js Github仓库
 Fork [minio-js upstream](https://github.com/minio/minio-js/fork) 源码仓库到你的个人仓库。
 
-Minio Javascript使用[gulp](http://gulpjs.com/)来管理它的依赖。
+MinIO Javascript使用[gulp](http://gulpjs.com/)来管理它的依赖。
 
 ```bash
 $ git clone https://github.com/$USER_ID/minio-js

--- a/examples/bucket-exists.js
+++ b/examples/bucket-exists.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/copy-object.js
+++ b/examples/copy-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/fget-object.js
+++ b/examples/fget-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/fput-object.js
+++ b/examples/fput-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/get-bucket-notification.js
+++ b/examples/get-bucket-notification.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/get-bucket-policy.js
+++ b/examples/get-bucket-policy.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/get-object.js
+++ b/examples/get-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/get-partialobject.js
+++ b/examples/get-partialobject.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/list-buckets.js
+++ b/examples/list-buckets.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/list-incomplete-uploads.js
+++ b/examples/list-incomplete-uploads.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/list-objects-v2.js
+++ b/examples/list-objects-v2.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/list-objects.js
+++ b/examples/list-objects.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/make-bucket.js
+++ b/examples/make-bucket.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/minio/listen-bucket-notification.js
+++ b/examples/minio/listen-bucket-notification.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-// Note that `listenBucketNotification` is only available for Minio, and not
+// Note that `listenBucketNotification` is only available for MinIO, and not
 // Amazon.
 
 const Minio = require('../')

--- a/examples/presigned-getobject-request-date.js
+++ b/examples/presigned-getobject-request-date.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/presigned-getobject.js
+++ b/examples/presigned-getobject.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/presigned-postpolicy.js
+++ b/examples/presigned-postpolicy.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/presigned-putobject.js
+++ b/examples/presigned-putobject.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/put-object.js
+++ b/examples/put-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/remove-all-bucket-notification.js
+++ b/examples/remove-all-bucket-notification.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/remove-bucket.js
+++ b/examples/remove-bucket.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/remove-incomplete-upload.js
+++ b/examples/remove-incomplete-upload.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/remove-object.js
+++ b/examples/remove-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/remove-objects.js
+++ b/examples/remove-objects.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/set-bucket-notification.js
+++ b/examples/set-bucket-notification.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/set-bucket-policy.js
+++ b/examples/set-bucket-policy.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/examples/stat-object.js
+++ b/examples/stat-object.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,7 +26,7 @@ var eslint = require('gulp-eslint')
 
 gulp.task('browserify', ['compile'], function() {
   browserify("./dist/main/minio.js", {
-    standalone: 'Minio'
+    standalone: 'MinIO'
   })
     .bundle()
     .on("error", function (err) { console.log("Error : " + err.message); })

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "url": "git+https://github.com/minio/minio-js.git"
   },
   "author": {
-    "name": "Minio, Inc.",
+    "name": "MinIO, Inc.",
     "email": "",
-    "url": "https://minio.io"
+    "url": "https://min.io"
   },
   "engines": {
     "node": ">= 0.10.0"

--- a/src/main/errors.js
+++ b/src/main/errors.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -105,10 +105,10 @@ export class Client {
     // User Agent should always following the below style.
     // Please open an issue to discuss any new changes here.
     //
-    //       Minio (OS; ARCH) LIB/VER APP/VER
+    //       MinIO (OS; ARCH) LIB/VER APP/VER
     //
     var libraryComments = `(${process.platform}; ${process.arch})`
-    var libraryAgent = `Minio ${libraryComments} minio-js/${Package.version}`
+    var libraryAgent = `MinIO ${libraryComments} minio-js/${Package.version}`
     // User agent block ends.
 
     this.transport = transport
@@ -223,7 +223,7 @@ export class Client {
   //
   // Generates User-Agent in the following style.
   //
-  //       Minio (OS; ARCH) LIB/VER APP/VER
+  //       MinIO (OS; ARCH) LIB/VER APP/VER
   //
   // __Arguments__
   // * `appName` _string_ - Application name.

--- a/src/main/notification.js
+++ b/src/main/notification.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/object-uploader.js
+++ b/src/main/object-uploader.js
@@ -1,5 +1,5 @@
 ﻿/*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/s3-endpoints.js
+++ b/src/main/s3-endpoints.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/signing.js
+++ b/src/main/signing.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015, 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -531,7 +531,7 @@ describe('functional tests', function() {
       client.initiateNewMultipartUpload(bucketName, _6mbObjectName, metaData, done)
     })
     step(`listIncompleteUploads(bucketName, prefix, recursive)_bucketName:${bucketName}, prefix:${_6mbObjectName}, recursive: true_`, function(done) {
-      // Minio's ListIncompleteUploads returns an empty list, so skip this on non-AWS.
+      // MinIO's ListIncompleteUploads returns an empty list, so skip this on non-AWS.
       // See: https://github.com/minio/minio/commit/75c43bfb6c4a2ace
       if (!client.host.includes('s3.amazonaws.com')) {
         this.skip()
@@ -549,7 +549,7 @@ describe('functional tests', function() {
         })
     })
     step(`listIncompleteUploads(bucketName, prefix, recursive)_bucketName:${bucketName}, recursive: true_`, function(done) {
-      // Minio's ListIncompleteUploads returns an empty list, so skip this on non-AWS.
+      // MinIO's ListIncompleteUploads returns an empty list, so skip this on non-AWS.
       // See: https://github.com/minio/minio/commit/75c43bfb6c4a2ace
       if (!client.host.includes('s3.amazonaws.com')) {
         this.skip()
@@ -1100,7 +1100,7 @@ describe('functional tests', function() {
   describe('bucket notifications', () => {
     describe('#listenBucketNotification', () => {
       before(function() {
-        // listenBucketNotification only works on Minio, so skip if
+        // listenBucketNotification only works on MinIO, so skip if
         // the host is Amazon.
         if (client.host.includes('s3.amazonaws.com')) {
           this.skip()

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -1,5 +1,5 @@
 /*
- * Minio Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 Minio, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -277,7 +277,7 @@ describe('Client', function() {
         accessKey: 'accesskey',
         secretKey: 'secretkey'
       })
-      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version}`,
+      assert.equal(`MinIO (${process.platform}; ${process.arch}) minio-js/${Package.version}`,
                    client.userAgent)
     })
     it('should set user agent', () => {
@@ -287,7 +287,7 @@ describe('Client', function() {
         secretKey: 'secretkey'
       })
       client.setAppInfo('test', '3.2.1')
-      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version} test/3.2.1`,
+      assert.equal(`MinIO (${process.platform}; ${process.arch}) minio-js/${Package.version} test/3.2.1`,
                    client.userAgent)
     })
     it('should set user agent without comments', () => {
@@ -297,7 +297,7 @@ describe('Client', function() {
         secretKey: 'secretkey'
       })
       client.setAppInfo('test', '3.2.1')
-      assert.equal(`Minio (${process.platform}; ${process.arch}) minio-js/${Package.version} test/3.2.1`,
+      assert.equal(`MinIO (${process.platform}; ${process.arch}) minio-js/${Package.version} test/3.2.1`,
                    client.userAgent)
     })
     it('should not set user agent without name', (done) => {


### PR DESCRIPTION
Official company name `Minio` became `MinIO`. 
This change requires all references in the code and documentation to be modified as `MinIO` and the links, `....://xxx.minio.io`, to be `....://xxx.min.io`.

## Description of the change
Here are the changes done .

Used Visual Studio Code Editor regular expressions to find and replace those patterns that match the desired text in all minio-js repo files. Here are the two regular expressions used to complete the job in 2 steps:

1. Set `files to include` to `*.md`, choose `Match Case` and `Use Regular Expression` and replace the links using the following regular expressions:

| Find | Replace |
| ------ | ----------- |
| (//(slack\|docs\|play\|dl\|blog)\.\|//)minio\.io | $1min.io |

The above regular expression, as can be seen, replaces the links that start with either `slack` or `docs` or ``play` or `dl` or `blog` or nothing before `minio.io`.

2. 
| Find | Replace |
| ------ | ----------- |
| \bMinio\b(?!( *=\|\.\| *from)) | MinIO |

The above regular expression replaces the string "Minio" with "MinIO" except the following forms:
 - `Minio =`, as in a variable setting like `var Minio = ....` in the code
 - `Minio.` as in `Minio.Client` in the code
 - `Minio from` as in `import * as Minio from ...` in the code


Please pay specific attention to the following changes:
gulpfile.js
line# 29

package.json
line#s 19, 21

src/main/minio.js
line#s 108, 111, 226

src/main/test/unit/test.js
line#s 280, 290, 300



