### PR TITLE
fGetobject-resume test is not testing resume

### DIFF
--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -620,26 +620,29 @@ describe('functional tests', function() {
   })
   describe('fGetObject-resume', () => {
     var localFile = `${tmpDir}/${_5mbObjectName}`
+    var etag = ''
     step(`putObject(bucketName, objectName, stream, metaData, cb)_bucketName:${bucketName}, objectName:${_5mbObjectName}, stream:5mb_`, done => {
       var stream = readableStream(_5mb)
-      client.putObject(bucketName, _5mbObjectName, stream, _5mb.length, {}, done)
+      client.putObject(bucketName, _5mbObjectName, stream, _5mb.length, {})
+      .then((resp) => {
+        etag = resp
+        done()
+      })
+        .catch(done)
     })
     step(`fGetObject(bucketName, objectName, filePath, callback)_bucketName:${bucketName}, objectName:${_5mbObjectName}, filePath:${localFile}`, done => {
-      client.statObject(bucketName, _5mbObjectName, (err, stat) => {
-        if (err) return done(new Error('failed to stat object'))
-        var bufPart = new Buffer(_100kb.length)
-        _5mb.copy(bufPart, 0, 0, _100kb.length)
-        var tmpFile = `${tmpDir}/${_5mbObjectName}.${stat.etag}.part.minio`
-        // create a partial file
-        fs.writeFileSync(tmpFile, bufPart)
-        client.fGetObject(bucketName, _5mbObjectName, localFile)
-          .then(() => {
-            var md5sum = crypto.createHash('md5').update(fs.readFileSync(localFile)).digest('hex')
-            if (md5sum === _5mbmd5) return done()
-            return done(new Error('md5sum mismatch'))
-          })
-          .catch(done)
-      })
+      var bufPart = new Buffer(_100kb.length)
+      _5mb.copy(bufPart, 0, 0, _100kb.length)
+      var tmpFile = `${tmpDir}/${_5mbObjectName}.${etag}.part.minio`
+      // create a partial file
+      fs.writeFileSync(tmpFile, bufPart)
+      client.fGetObject(bucketName, _5mbObjectName, localFile)
+        .then(() => {
+          var md5sum = crypto.createHash('md5').update(fs.readFileSync(localFile)).digest('hex')
+          if (md5sum === _5mbmd5) return done()
+          return done(new Error('md5sum mismatch'))
+        })
+        .catch(done)
     })
     step(`removeObject(bucketName, objectName, callback)_bucketName:${bucketName}, objectName:${_5mbObjectName}_`, done => {
       fs.unlinkSync(localFile)

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -624,10 +624,10 @@ describe('functional tests', function() {
     step(`putObject(bucketName, objectName, stream, metaData, cb)_bucketName:${bucketName}, objectName:${_5mbObjectName}, stream:5mb_`, done => {
       var stream = readableStream(_5mb)
       client.putObject(bucketName, _5mbObjectName, stream, _5mb.length, {})
-      .then((resp) => {
-        etag = resp
-        done()
-      })
+        .then((resp) => {
+          etag = resp
+          done()
+        })
         .catch(done)
     })
     step(`fGetObject(bucketName, objectName, filePath, callback)_bucketName:${bucketName}, objectName:${_5mbObjectName}, filePath:${localFile}`, done => {

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -627,8 +627,8 @@ describe('functional tests', function() {
     step(`fGetObject(bucketName, objectName, filePath, callback)_bucketName:${bucketName}, objectName:${_5mbObjectName}, filePath:${localFile}`, done => {
       client.statObject(bucketName, _5mbObjectName, (err, stat) => {
         if (err) return done(new Error('failed to stat object'))
-        var bufPart = new Buffer(_100kb.length);
-        _5mb.copy(bufPart, 0, 0, _100kb.length);
+        var bufPart = new Buffer(_100kb.length)
+        _5mb.copy(bufPart, 0, 0, _100kb.length)
         var tmpFile = `${tmpDir}/${_5mbObjectName}.${stat.etag}.part.minio`
         // create a partial file
         fs.writeFileSync(tmpFile, bufPart)


### PR DESCRIPTION
As it was before the following happened
1. call putObject with the 5mb file. In reality a multipart upload is performed with the file as the only part
2. Create a part file using the object name and the md5 hash and put in 100kb of random data
3. Call fGetObject. fGetObject will look for a part file containing the object name and the etag, since a multipart upload was performed, the etag will not match the md5 for aws (prob minio as well).
4. Test passes as the md5 hash matches for the the uploaded and the downloaded file

With the PR we instead call statobject and use the etag we get to create the part file. Also the part file will contain the first 100kb from the 5mb file, instead of 100kb of random data. The fGetObject will then use the part file, and skip those bytes in the part file, resulting in an actual resume as the test implies. The resulting md5 hash will match with the one we uploaded so the test will pass.
 
