### PR TITLE
Change content-language to a valid ISO 639-1 language code to make tests pass for GCS backend

### DIFF
--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -96,7 +96,7 @@ describe('functional tests', function() {
 
   var metaData = {
     'Content-Type': 'text/html',
-    'Content-Language': 123,
+    'Content-Language': 'en',
     'X-Amz-Meta-Testing': 1234,
     'randomstuff': 5678
   }


### PR DESCRIPTION
Related issue: https://github.com/minio/minio-js/issues/766