### PR TITLE
Example: Use QueueConfig instead of TopicConfig

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -931,16 +931,16 @@ __Example__
 // Create a new notification object
 var bucketNotification = new Minio.NotificationConfig();
 
-// Setup a new topic configuration
-var arn = Minio.buildARN('aws', 'sns', 'us-west-2', '408065449417', 'TestTopic')
-var topic = new Minio.TopicConfig(arn)
-topic.addFilterSuffix('.jpg')
-topic.addFilterPrefix('myphotos/')
-topic.addEvent(Minio.ObjectReducedRedundancyLostObject)
-topic.addEvent(Minio.ObjectCreatedAll)
+// Setup a new Queue configuration
+var arn = Minio.buildARN('aws', 'sqs', 'us-west-2', '1', 'webhook')
+var queue = new Minio.QueueConfig(arn)
+queue.addFilterSuffix('.jpg')
+queue.addFilterPrefix('myphotos/')
+queue.addEvent(Minio.ObjectReducedRedundancyLostObject)
+queue.addEvent(Minio.ObjectCreatedAll)
 
-// Add the topic to the overall notification object
-bucketNotification.add(topic)
+// Add the queue to the overall notification object
+bucketNotification.add(queue)
 
 minioClient.setBucketNotification('mybucket', bucketNotification, function(err) {
   if (err) return console.log(err)

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -879,18 +879,18 @@ __示例__
 
 ```js
 // Create a new notification object
-var bucketNotification = new Notify.BucketNotification();
+var bucketNotification = new Minio.NotificationConfig();
 
-// Setup a new topic configuration
-var arn = Notify.newARN('aws', 'sns', 'us-west-2', '408065449417', 'TestTopic')
-var topic = new Notify.TopicConfig(arn)
-topic.addFilterSuffix('.jpg')
-topic.addFilterPrefix('myphotos/')
-topic.addEvent(Notify.ObjectReducedRedundancyLostObject)
-topic.addEvent(Notify.ObjectCreatedAll)
+// Setup a new Queue configuration
+var arn = Minio.buildARN('aws', 'sqs', 'us-west-2', '1', 'webhook')
+var queue = new Minio.QueueConfig(arn)
+queue.addFilterSuffix('.jpg')
+queue.addFilterPrefix('myphotos/')
+queue.addEvent(Minio.ObjectReducedRedundancyLostObject)
+queue.addEvent(Minio.ObjectCreatedAll)
 
-// Add the topic to the overall notification object
-bucketNotification.addTopicConfiguration(topic)
+// Add the queue to the overall notification object
+bucketNotification.add(queue)
 
 minioClient.setBucketNotification('mybucket', bucketNotification, function(err) {
   if (err) return console.log(err)

--- a/examples/set-bucket-notification.js
+++ b/examples/set-bucket-notification.js
@@ -1,5 +1,5 @@
 /*
- * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016 MinIO, Inc.
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2016-2019 MinIO, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,20 +21,22 @@
 var Minio = require('minio')
 
 var s3Client = new Minio.Client({
-  endPoint: 's3.amazonaws.com',
+  endPoint: 'localhost',
+  port: 9000,
+  useSSL: false,
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY'
 })
 
 var config = new Minio.NotificationConfig()
-var arn = Minio.buildARN('aws', 'sns', 'us-east-1', 111112222233, 'topicresource')
-var topic = new Minio.TopicConfig(arn)
+var arn = Minio.buildARN('minio', 'sqs', '', 1, 'webhook')
+var queue = new Minio.QueueConfig(arn)
 
-topic.addFilterSuffix('.jpg')
-topic.addFilterPrefix('myphotos/')
-topic.addEvent(Minio.ObjectCreatedAll)
+queue.addFilterSuffix('.jpg')
+queue.addFilterPrefix('myphotos/')
+queue.addEvent(Minio.ObjectCreatedAll)
 
-config.add(topic)
+config.add(queue)
 
 s3Client.setBucketNotification('my-bucketname', config, function(e) {
   if (e) {


### PR DESCRIPTION
MinIO doesn't support `TopicConfig`, but supports `QueueConfig`. Changing the example to use `QueueConfig` instead of `TopicConfig`, which works only on `AWS S3`

Fixes #775