### PR TITLE
Ensure that tests are run on CI Platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ node_js:
 - '8'
 
 script:
+- gulp test
 - gulp browserify
 - gulp lint
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ environment:
 build_script:
   - npm install
   - npm install -g gulp
+  - gulp test
   - gulp browserify
   - gulp lint
 


### PR DESCRIPTION
Due to 'npm prepublish' being deprecated, the relevant command was moved
to 'npm prepublishOnly', which doesn't run on local 'npm install' and
resulted in our tests not being ran on Appveyor. The functionality of
'npm prepublish' is preserved on 'npm prepare', but that is already
reserved for users who install the package directly from the GitHub URL.
Similarly, there were changes made to the package.json file that caused
tests to not being run on Travis as well. Therefore, an additional line
has been added to both appveyor.yml and travis.yml to run the tests.