### PR TITLE
Fix multipart upload with keepalive memory leak

### DIFF
--- a/src/main/object-uploader.js
+++ b/src/main/object-uploader.js
@@ -198,6 +198,9 @@ export default class ObjectUploader extends Transform {
 
       this.etags.push({part: partNumber, etag})
 
+      // Ignore the 'data' event so that the stream closes. (nodejs stream requirement)
+      response.on('data', () => {})
+
       // We're ready for the next chunk.
       callback()
     })


### PR DESCRIPTION
- Socket were not released by each uploaded part http request.
- When using http agent with keepalive, each request were still referenced through sockets and indirectly reference chunk data.