### PR TITLE
Fix: avoid metadata mutation in fPutObject

### DIFF
--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -306,8 +306,9 @@ export function insertContentType(metaData, filePath) {
   }
   // if `content-type` attribute is not present in metadata,
   // then infer it from the extension in filePath
-  metaData['content-type'] = probeContentType(filePath)
-  return metaData
+  var newMetadata = Object.assign({}, metaData)
+  newMetadata['content-type'] = probeContentType(filePath)
+  return newMetadata
 }
 
 // Function prepends metadata with the appropriate prefix if it is not already on

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -895,7 +895,7 @@ export class Client {
     }
 
     // Inserts correct `content-type` attribute based on metaData and filePath
-    insertContentType(metaData, filePath)
+    metaData = insertContentType(metaData, filePath)
 
     //Updates metaData to have the correct prefix if needed
     metaData = prependXAMZMeta(metaData)


### PR DESCRIPTION
Consider the following code:

```javascript
const metadata = {
  some: 'thing',
};

for (const file of files) {
  client.fPutObject(bucketName, objectName, file, metadata, callback);
}
```

The problem with this code is that it mutates the metadata object. After the first iteration the object contains the 'content-type' property. What follows is the wrong 'content-type' being set on the remaining files. 

I solved the problem by creating a new object instead of mutating the original one.