### PR TITLE
WIP: Use camaro for xml parsing

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
         node_version: [8.x, 10.x, 12.x]
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node_version }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -16,7 +16,7 @@ jobs:
       max-parallel: 4
       matrix:
         node_version: [8.x, 10.x, 12.x]
-        os: [ubuntu-latest]
+        os: [ubuntu-latest, windows-latest]
     steps:
     - uses: actions/checkout@v1
     - name: Use Node.js ${{ matrix.node_version }}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "async": "^3.1.0",
     "block-stream2": "^2.0.0",
+    "camaro": "^3.0.19",
     "es6-error": "^4.1.1",
     "json-stream": "^1.0.0",
     "lodash": "^4.14.2",

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -149,7 +149,8 @@ export function parseBucketNotification(xml) {
 
 // parse XML response for bucket region
 export function parseBucketRegion(xml) {
-  return parseXml(xml)
+  var result = transform(xml, { region: 'LocationConstraint'})
+  return result.region
 }
 
 // parse XML response for list parts of an in progress multipart upload
@@ -176,9 +177,11 @@ export function parseListParts(xml) {
 }
 
 // parse XML response when a new multipart upload is initiated
-export function parseInitiateMultipart(xml) {  
-  var xmlobj = parseXml(xml)
-  if (xmlobj.UploadId) return xmlobj.UploadId[0]
+export function parseInitiateMultipart(xml) {
+  var result = transform(xml, {
+    uploadId: 'InitiateMultipartUploadResult/UploadId'
+  })
+  if (result.UploadId) return result.UploadId
   throw new errors.InvalidXMLError('UploadId missing in XML')
 }
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -23,14 +23,14 @@ import * as errors from './errors.js'
 // parse error XML response
 export function parseError(xml, headerInfo) {
   var template = {
-    code: "Error/Code",
-    message: "Error/Message",
-    key: "Error/Key",
-    bucketname: "Error/BucketName",
-    resource: "Error/Resource",
-    region: "Error/Region",
-    requestid: "Error/RequestId",
-    hostid: "Error/HostId"
+    code: 'Error/Code',
+    message: 'Error/Message',
+    key: 'Error/Key',
+    bucketname: 'Error/BucketName',
+    resource: 'Error/Resource',
+    region: 'Error/Region',
+    requestid: 'Error/RequestId',
+    hostid: 'Error/HostId'
   }
   var xmlError = transform(xml, template)
   var e = new errors.S3Error(xmlError.message)
@@ -181,10 +181,10 @@ export function parseCompleteMultipart(xml) {
 export function parseListObjects(xml) {
   var template = {
     objects: ['ListBucketResult/Contents', {
-      name: "Key",
-      lastModified: "LastModified",
+      name: 'Key',
+      lastModified: 'LastModified',
       etag: "translate(ETag, '\"', '')",
-      size: "number(Size)"
+      size: 'number(Size)'
     }],
     isTruncated: 'boolean(ListBucketResult/IsTruncated = "true")',
     nextMarker: 'ListBucketResult/NextMarker'
@@ -207,10 +207,10 @@ export function parseListObjects(xml) {
 export function parseListObjectsV2(xml) {
   var template = {
     objects: ['ListBucketResult/Contents', {
-      name: "Key",
-      lastModified: "LastModified",
+      name: 'Key',
+      lastModified: 'LastModified',
       etag: "translate(ETag, '\"', '')",
-      size: "number(Size)"
+      size: 'number(Size)'
     }],
     isTruncated: 'boolean(ListBucketResult/IsTruncated = "true")',
     nextContinuationToken: 'ListBucketResult/nextContinuationToken'

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -186,33 +186,20 @@ export function parseInitiateMultipart(xml) {
 
 // parse XML response when a multipart upload is completed
 export function parseCompleteMultipart(xml) {
-  // var template = {
-  //   location: '',
-  //   bucket: '',
-  //   key: '',
-  //   etag: ''
-  // }
-
-  // var result = transform(xml, template)
-  // return result 
-
-  var xmlobj = parseXml(xml)
-  if (xmlobj.Location) {
-    var location = xmlobj.Location[0]
-    var bucket = xmlobj.Bucket[0]
-    var key = xmlobj.Key[0]
-    var etag = xmlobj.ETag[0].replace(/^"/g, '').replace(/"$/g, '')
-      .replace(/^&quot;/g, '').replace(/&quot;$/g, '')
-      .replace(/^&#34;/g, '').replace(/^&#34;$/g, '')
-
-    return {location, bucket, key, etag}
+  var template = {
+    errCode: 'Error/Code',
+    errMessage: 'Error/Message',
+    location: 'CompleteMultipartUploadOutput/Location',
+    bucket: 'CompleteMultipartUploadOutput/Bucket',
+    key: 'CompleteMultipartUploadOutput/Key',
+    etag: "translate(CompleteMultipartUploadOutput/ETag, '\"', '')"
   }
-  // Complete Multipart can return XML Error after a 200 OK response
-  if (xmlobj.Code && xmlobj.Message) {
-    var errCode = xmlobj.Code[0]
-    var errMessage = xmlobj.Message[0]
-    return {errCode, errMessage}
+
+  var result = transform(xml, template)
+  if (result.errCode && result.errMessage) {
+    return _.pick(result, ['errCode', 'errMessage'])
   }
+  return result 
 }
 
 // parse XML response for list objects in a bucket

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -34,12 +34,7 @@ export function parseError(xml, headerInfo) {
   }
   var xmlError = transform(xml, template)
   var e = new errors.S3Error(xmlError.message)
-  _.each(xmlError, (value, key) => {
-    e[key] = value
-  })
-  _.each(headerInfo, (value, key) => {
-    e[key] = value
-  })
+  Object.assign(e, xmlError, headerInfo)
   return e
 }
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -80,25 +80,28 @@ export function parseCopyObject(xml) {
 
 // parse XML response for listing in-progress multipart uploads
 export function parseListMultipart(xml) {
-  var result = {
-    uploads: [],
-    prefixes: [],
-    isTruncated: false
+  var template = {
+    uploads: ['ListMultipartUploadsOutput/Upload', {
+      key: 'Key',
+      uploadId: 'UploadId',
+      initiated: 'Initiated',
+    }],
+    prefixes: ['ListMultipartUploadsOutput/CommonPrefixes/Prefix', {
+      prefix: '.'
+    }],
+    isTruncated: 'boolean(ListMultipartUploadsOutput/IsTruncated = "true")',
+    nextKeyMarker: 'NextKeyMarker',
+    nextUploadIdMarker: 'NextUploadIdMarker',
   }
-  var xmlobj =  parseXml(xml)
-  if (xmlobj.IsTruncated && xmlobj.IsTruncated[0] === 'true') result.isTruncated = true
-  if (xmlobj.NextKeyMarker) result.nextKeyMarker =  xmlobj.NextKeyMarker[0]
-  if (xmlobj.NextUploadIdMarker) result.nextUploadIdMarker = xmlobj.NextUploadIdMarker[0]
-  if (xmlobj.CommonPrefixes) xmlobj.CommonPrefixes.forEach(prefix => {
-    result.prefixes.push({prefix: prefix[0]})
-  })
-  if (xmlobj.Upload) xmlobj.Upload.forEach(upload => {
-    result.uploads.push({
-      key: upload.Key[0],
-      uploadId: upload.UploadId[0],
-      initiated: new Date(upload.Initiated[0])
-    })
-  })
+
+  var result = transform(xml, template)
+  // backward compat
+  if (!result.nextKeyMarker) {
+    delete result.nextKeyMarker
+  }
+  if (!result.nextUploadIdMarker) {
+    delete result.nextUploadIdMarker
+  }
   return result
 }
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -232,36 +232,12 @@ export function parseListObjects(xml) {
   if (!result.isTruncated) {
     delete result.nextMarker
   }
-
-  // var result = {
-  //   objects: [],
-  //   isTruncated: false
-  // }
-  // var nextMarker
-  // var xmlobj = parseXml(xml)
-  // if (xmlobj.IsTruncated && xmlobj.IsTruncated[0] === 'true') result.isTruncated = true
-  // if (xmlobj.Contents) {
-  //   xmlobj.Contents.forEach(content => {
-  //     var name = content.Key[0]
-  //     var lastModified = new Date(content.LastModified[0])
-  //     var etag = content.ETag[0].replace(/^"/g, '').replace(/"$/g, '')
-  //       .replace(/^&quot;/g, '').replace(/&quot;$/g, '')
-  //       .replace(/^&#34;/g, '').replace(/^&#34;$/g, '')
-  //     var size = +content.Size[0]
-  //     result.objects.push({name, lastModified, etag, size})
-  //     nextMarker = name
-  //   })
-  // }
-  // if (xmlobj.CommonPrefixes) {
-  //   xmlobj.CommonPrefixes.forEach(commonPrefix => {
-  //     var prefix = commonPrefix.Prefix[0]
-  //     var size = 0
-  //     result.objects.push({prefix, size})
-  //   })
-  // }
-  // if (result.isTruncated) {
-  //   result.nextMarker = xmlobj.NextMarker ? xmlobj.NextMarker[0]: nextMarker
-  // }
+  _.forEach(result.objects, o => {
+    if (o.lastModified) {
+      o.lastModified = new Date(o.lastModified)
+    }
+  })
+  // TODO(Anh): implement common prefix
   return result
 }
 
@@ -283,33 +259,11 @@ export function parseListObjectsV2(xml) {
   if (!result.nextContinuationToken) {
     delete result.nextContinuationToken
   }
-
-  // var result = {
-  //   objects: [],
-  //   isTruncated: false
-  // }
-  // var xmlobj = parseXml(xml)
-  // if (xmlobj.IsTruncated && xmlobj.IsTruncated[0] === 'true') result.isTruncated = true
-  // if (xmlobj.NextContinuationToken) result.nextContinuationToken = xmlobj.NextContinuationToken[0]
-
-  // if (xmlobj.Contents) {
-  //   xmlobj.Contents.forEach(content => {
-  //     var name = content.Key[0]
-  //     var lastModified = new Date(content.LastModified[0])
-  //     var etag = content.ETag[0].replace(/^"/g, '').replace(/"$/g, '')
-  //       .replace(/^&quot;/g, '').replace(/&quot;$/g, '')
-  //       .replace(/^&#34;/g, '').replace(/^&#34;$/g, '')
-  //     var size = +content.Size[0]
-  //     result.objects.push({name, lastModified, etag, size})
-  //   })
-  // }
-  // if (xmlobj.CommonPrefixes) {
-  //   xmlobj.CommonPrefixes.forEach(commonPrefix => {
-  //     var prefix = commonPrefix.Prefix[0]
-  //     var size = 0
-  //     result.objects.push({prefix, size})
-  //   })
-  // }
-  
+  _.forEach(result.objects, o => {
+    if (o.lastModified) {
+      o.lastModified = new Date(o.lastModified)
+    }
+  })
+  // TODO(Anh): implement commonPrefix parsing  
   return result
 }

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -181,7 +181,7 @@ export function parseInitiateMultipart(xml) {
   var result = transform(xml, {
     uploadId: 'InitiateMultipartUploadResult/UploadId'
   })
-  if (result.UploadId) return result.UploadId
+  if (result.uploadId) return result.uploadId
   throw new errors.InvalidXMLError('UploadId missing in XML')
 }
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -90,18 +90,13 @@ export function parseListMultipart(xml) {
       prefix: '.'
     }],
     isTruncated: 'boolean(ListMultipartUploadsOutput/IsTruncated = "true")',
-    nextKeyMarker: 'NextKeyMarker',
-    nextUploadIdMarker: 'NextUploadIdMarker',
+    nextKeyMarker: 'ListMultipartUploadsOutput/NextKeyMarker',
+    nextUploadIdMarker: 'ListMultipartUploadsOutput/NextUploadIdMarker',
   }
-
   var result = transform(xml, template)
   // backward compat
-  if (!result.nextKeyMarker) {
-    delete result.nextKeyMarker
-  }
-  if (!result.nextUploadIdMarker) {
-    delete result.nextUploadIdMarker
-  }
+  if (!result.nextKeyMarker) delete result.nextKeyMarker
+  if (!result.nextUploadIdMarker) delete result.nextUploadIdMarker
   return result
 }
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -121,67 +121,31 @@ export function parseListBucket(xml) {
 
 // parse XML response for bucket notification
 export function parseBucketNotification(xml) {
-  var result = {
-    TopicConfiguration  : [],
-    QueueConfiguration  : [],
-    CloudFunctionConfiguration : [],
+  const filterRuleTemplate = ['S3Key/FilterRule', {
+    Name: 'Name',
+    Value: 'Value'
+  }]
+  var template = {
+    TopicConfiguration  : ['NotificationConfiguration/TopicConfiguration', {
+      Id: 'Id',
+      Topic: 'Topic',
+      Event: 'Event',
+      Filter: filterRuleTemplate
+    }],
+    QueueConfiguration  : ['NotificationConfiguration/QueueConfiguration', {
+      Id: 'Id',
+      Queue: 'Queue',
+      Event: 'Event',
+      Filter: filterRuleTemplate
+    }],
+    CloudFunctionConfiguration : ['NotificationConfiguration/CloudFunctionConfiguration', {
+      Id: 'Id',
+      CloudFunction: 'CloudFunction',
+      Event: 'Event',
+      Filter: filterRuleTemplate
+    }]
   }
-  // Parse the events list
-  var genEvents = function(events) {
-    var result = []
-    if (events) {
-      events.forEach(s3event => {
-        result.push(s3event)
-      })
-    }
-    return result
-  }
-  // Parse all filter rules
-  var genFilterRules = function(filters) {
-    var result = []
-    if (filters && filters[0].S3Key && filters[0].S3Key[0].FilterRule) {
-      filters[0].S3Key[0].FilterRule.forEach(rule => {
-        var Name = rule.Name[0]
-        var Value = rule.Value[0]
-        result.push({Name, Value})
-      })
-    }
-    return result
-  }
-
-  var xmlobj = parseXml(xml)
-
-  // Parse all topic configurations in the xml
-  if (xmlobj.TopicConfiguration) {
-    xmlobj.TopicConfiguration.forEach(config => {
-      var Id = config.Id[0]
-      var Topic = config.Topic[0]
-      var Event = genEvents(config.Event)
-      var Filter = genFilterRules(config.Filter)
-      result.TopicConfiguration.push({ Id, Topic, Event, Filter})
-    })
-  }
-  // Parse all topic configurations in the xml
-  if (xmlobj.QueueConfiguration) {
-    xmlobj.QueueConfiguration.forEach(config => {
-      var Id = config.Id[0]
-      var Queue = config.Queue[0]
-      var Event = genEvents(config.Event)
-      var Filter = genFilterRules(config.Filter)
-      result.QueueConfiguration.push({ Id, Queue, Event, Filter})
-    })
-  }
-  // Parse all QueueConfiguration arrays
-  if (xmlobj.CloudFunctionConfiguration) {
-    xmlobj.CloudFunctionConfiguration.forEach(config => {
-      var Id = config.Id[0]
-      var CloudFunction = config.CloudFunction[0]
-      var Event = genEvents(config.Event)
-      var Filter = genFilterRules(config.Filter)
-      result.CloudFunctionConfiguration.push({ Id, CloudFunction, Event, Filter})
-    })
-  }
-  
+  var result = transform(xml, template)
   return result
 }
 


### PR DESCRIPTION
I just draft a quick PR. It's still a WIP.

Not sure if  you're interested in this?

I switch `xml2js` for `camaro`. the transformation process is done via camaro. So we have to rely less on writing code to transform but do it via the xpath template instead.

example: 

`isTruncated` prop can be write as such: 

```js
isTruncated: 'boolean(ListMultipartUploadsOutput/IsTruncated = "true")',
```

Or getting all uploads node in the xml and output an array of object with (`key`, `uploadId` and `initiated` prop) can be written as this:

```js
uploads: ['ListMultipartUploadsOutput/Upload', {
      key: 'Key',
      uploadId: 'UploadId',
      initiated: 'Initiated',
 }],
```
A typical transform function will looks like this now

```js
export function parseListMultipart(xml) {
  var template = {
    uploads: ['ListMultipartUploadsOutput/Upload', {
      key: 'Key',
      uploadId: 'UploadId',
      initiated: 'Initiated',
    }],
    prefixes: ['ListMultipartUploadsOutput/CommonPrefixes/Prefix', {
      prefix: '.'
    }],
    isTruncated: 'boolean(ListMultipartUploadsOutput/IsTruncated = "true")',
    nextKeyMarker: 'ListMultipartUploadsOutput/NextKeyMarker',
    nextUploadIdMarker: 'ListMultipartUploadsOutput/NextUploadIdMarker',
  }
  var result = transform(xml, template)
  // backward compat
  if (!result.nextKeyMarker) delete result.nextKeyMarker
  if (!result.nextUploadIdMarker) delete result.nextUploadIdMarker
  return result
}
```