### PR TITLE
Update bucketExists in API.md

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -156,7 +156,7 @@ minioClient.listBuckets(function(err, buckets) {
 ```
 
 <a name="bucketExists"></a>
-#### bucketExists(bucketName, callback)
+#### bucketExists(bucketName[, callback])
 
 Checks if a bucket exists.
 
@@ -167,7 +167,7 @@ __Parameters__
 | Param  | Type  | Description  |
 |---|---|---|
 | `bucketName`  |  _string_ | Name of the bucket.  |
-| `callback(err, exists)`  | _function_  | `exists` is a boolean which indicates whether `bucketName` exists or not. `err` is set when an error occurs during the operation. |
+| `callback(err, exists)`  | _function_  | `exists` is a boolean which indicates whether `bucketName` exists or not. `err` is set when an error occurs during the operation. If no callback is passed, a `Promise` is returned. |
 
 __Example__
 


### PR DESCRIPTION
Since `bucketExists` was [promisified](https://github.com/minio/minio-js/blob/518e5a8815dd579f3fcd2d2a4f4cb2599ad3d580/src/main/minio.js#L2115), it should be reflected in the API document.