### PR TITLE
ListObjectsV2Metadata: userMetadata null check

### DIFF
--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -323,7 +323,12 @@ export function parseListObjectsV2WithMetadata(xml) {
         .replace(/^&quot;/g, '').replace(/&quot;$/g, '')
         .replace(/^&#34;/g, '').replace(/^&#34;$/g, '')
       var size = +content.Size[0]
-      var metadata = content.UserMetadata[0]
+      var metadata
+      if (content.UserMetadata != null) {
+        metadata = content.UserMetadata[0]
+      } else {
+        metadata = null
+      }
       result.objects.push({name, lastModified, etag, size, metadata})
     })
   }


### PR DESCRIPTION
userMetaData returned when ListObjectsV2Metadata is null in the case of Azure Gateway. Adding a null check before accessing an index in userMetadata