### PR TITLE
parseListObjects处理prefix逻辑调整

### DIFF
--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -283,10 +283,12 @@ export function parseListObjects(xml) {
     })
   }
   if (xmlobj.CommonPrefixes) {
+    if (!Array.isArray(xmlobj.CommonPrefixes)) {
+      xmlobj.CommonPrefixes = Array(xmlobj.CommonPrefixes)
+    }
     xmlobj.CommonPrefixes.forEach(commonPrefix => {
-      var prefix = commonPrefix.Prefix[0]
-      var size = 0
-      result.objects.push({prefix, size})
+      var prefix = commonPrefix.Prefix
+      result.objects.push({ name: prefix })
     })
   }
   if (result.isTruncated) {
@@ -324,10 +326,12 @@ export function parseListObjectsV2(xml) {
     })
   }
   if (xmlobj.CommonPrefixes) {
+    if (!Array.isArray(xmlobj.CommonPrefixes)) {
+      xmlobj.CommonPrefixes = Array(xmlobj.CommonPrefixes)
+    }
     xmlobj.CommonPrefixes.forEach(commonPrefix => {
-      var prefix = commonPrefix.Prefix[0]
-      var size = 0
-      result.objects.push({prefix, size})
+      var prefix = commonPrefix.Prefix
+      result.objects.push({ name: prefix })
     })
   }
   return result
@@ -368,10 +372,12 @@ export function parseListObjectsV2WithMetadata(xml) {
     })
   }
   if (xmlobj.CommonPrefixes) {
+    if (!Array.isArray(xmlobj.CommonPrefixes)) {
+      xmlobj.CommonPrefixes = Array(xmlobj.CommonPrefixes)
+    }
     xmlobj.CommonPrefixes.forEach(commonPrefix => {
-      var prefix = commonPrefix.Prefix[0]
-      var size = 0
-      result.objects.push({prefix, size})
+      var prefix = commonPrefix.Prefix
+      result.objects.push({ name: prefix })
     })
   }
   return result


### PR DESCRIPTION
问题：
1.当前桶下只添加了一个prefix的时候CommonPrefixes是一个对象，不是数组
2.commonPrefix是一个{Prefix:xxx}对象，故而commonPrefix.Prefix[0]获取的是prefix的首字母，并非完整的prefix
解决办法
1.与xmlobj.Contents一样，xmlobj.CommonPrefixes添加数组判断
2.修改prefixes列表返回对象为{name：prefix}