### PR TITLE
feat: add bucket versioning support

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -616,29 +616,59 @@ Copy a source object into a new object in the specified bucket.
 
 __Parameters__
 
-
 | Param  |  Type | Description  |
 |---|---|---|
-| `bucketName`  | _string_  | Name of the bucket.  |
-|`objectName`   |_string_   | Name of the object.  |
-| `sourceObject`  | _string_  | Path of the file to be copied.  |
-| `conditions`  | _CopyConditions_  | Conditions to be satisfied before allowing object copy.  |
-| `callback(err, {etag, lastModified})`  |  _function_ | Non-null `err` indicates error, `etag` _string_ and lastModified _Date_ are the etag and the last modified date of the object newly copied. If no callback is passed, a `Promise` is returned. |
+| `src` | _CopySrcOptions_  | Argument describing the source object. |
+| `dst` | _CopyDestOptions_ | Argument describing the destination object. |
+| `callback(err, {etag, lastModified, versionId})` | _function_ | Non-null `err` indicates error, `etag` _string_ and lastModified _Date_ and `versionId` _string_ are the etag, the last modified date and version ID of the object newly copied. If no callback is passed, a `Promise` is returned. |
 
-__Example__
+__Example 1__
 
 ```js
-var conds = new Minio.CopyConditions()
-conds.setMatchETag('bd891862ea3e22c93ed53a098218791d')
-minioClient.copyObject('mybucket', 'newobject', '/mybucket/srcobject', conds, function(e, data) {
+var src = new Minio.CopySrcOptions()
+src.bucketName = 'mybucket'
+src.objectName = 'srcobject'
+
+var dst = new Minio.CopyDestOptions()
+dst.bucketName = 'mybucket'
+dst.objectName = 'newobject'
+
+minioClient.copyObject(src, dst, function(e, data) {
   if (e) {
     return console.log(e)
   }
   console.log("Successfully copied the object:")
   console.log("etag = " + data.etag + ", lastModified = " + data.lastModified)
+  if (data.versionId) {
+    console.log("versionId = " + data.versionId)
+  }
 })
 ```
 
+__Example 2__
+
+```js
+var src = new Minio.CopySrcOptions()
+src.bucketName = 'mybucket'
+src.objectName = 'srcobject'
+src.matchETag = 'bd891862ea3e22c93ed53a098218791d'
+src.versionID = '3d789c31-b8f9-44ef-8fec-6b441e8e0587'
+
+var dst = new Minio.CopyDestOptions()
+dst.bucketName = 'mybucket'
+dst.objectName = 'newobject'
+
+minioClient.copyObject(src, dst, function(e, data) {
+  if (e) {
+    return console.log(e)
+  }
+  console.log("Successfully copied the object:")
+  console.log("etag = " + data.etag + ", lastModified = " + data.lastModified)
+  if (data.versionId) {
+    console.log("versionId = " + data.versionId)
+  }
+})
+```
 
 <a name="statObject"></a>
 ### statObject(bucketName, objectName[, callback])

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "mkdirp": "^0.5.1",
     "querystring": "0.2.0",
     "through2": "^3.0.1",
-    "xml": "^1.0.0",
-    "xml2js": "^0.4.15"
+    "xml": "^1.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -213,3 +213,8 @@ export function getNotificationTransformer() {
   // This will parse and return each object.
   return new JSONParser()
 }
+
+// Parses versioning config
+export function getVersioningConfiguration() {
+  return getConcater(xmlParsers.parseVersioningConfiguration)
+}


### PR DESCRIPTION
Closes #863, closes #860

This PR adds support for bucket versioning. The design is inspired by `minio-py` SDK.

BREAKING CHANGES:
1. `putObject` now returns an object instead of a string (etag)
2. `fPutObject` now returns an object instead of a string (etag)

I understand it is desired to move away from `xml2js` in favor of `fast-xml-parser` so the new methods use `fast-xml-parser` and I refactored `setBucketNotification` accordingly.

PS. the last step (i.e. `listenBucketNotification`) of `bucket notifications` functional test fail on master as well as in this branch.