### PR TITLE
VersionId support in removeObject API

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -666,6 +666,7 @@ __Parameters__
 |---|---|---|
 |`bucketName`   |  _string_ | Name of the bucket.  |
 | objectName  |  _string_ | Name of the object.  |
+| removeOpts  |  _object_ | object containing delete options e.g versionId of the object.  |
 | `callback(err)`  | _function_  | Callback function is called with non `null` value in case of error. If no callback is passed, a `Promise` is returned. |
 
 
@@ -678,6 +679,17 @@ minioClient.removeObject('mybucket', 'photo.jpg', function(err) {
     return console.log('Unable to remove object', err)
   }
   console.log('Removed the object')
+})
+```
+
+or to remove a specified **version** of an object on a **versioning enabled** bucket.
+
+```js
+minioClient.removeObject('mybucket', 'photo.jpg',{versionId:"089a5b47-ec2e-405f-b6bc-bb7a8cc3511c"} ,function(err) {
+  if (err) {
+    return console.log('Unable to remove object', err)
+  }
+  console.log('Removed the object version')
 })
 ```
 

--- a/examples/remove-object.js
+++ b/examples/remove-object.js
@@ -15,8 +15,8 @@
  */
 
 
-  // Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and
-  // my-objectname are dummy values, please replace them with original values.
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY, my-bucketname and
+// my-objectname are dummy values, please replace them with original values.
 
 var Minio = require('minio')
 
@@ -27,6 +27,14 @@ var s3Client = new Minio.Client({
 })
 // Remove an object name my-objectname.
 s3Client.removeObject('my-bucketname', 'my-objectname', function(e) {
+  if (e) {
+    return console.log(e)
+  }
+  console.log("Success")
+})
+
+// Remove an object name my-objectname and versionId.
+s3Client.removeObject('my-bucketname', 'my-objectname', {versionId:"089a5b47-ec2e-405f-b6bc-bb7a8cc3511c"}, function(e) {
   if (e) {
     return console.log(e)
   }

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1443,19 +1443,34 @@ export class Client {
   // __Arguments__
   // * `bucketName` _string_: name of the bucket
   // * `objectName` _string_: name of the object
+  // * `removeOpts` _object_: object containing delete options e.g versionId of the object
   // * `callback(err)` _function_: callback function is called with non `null` value in case of error
-  removeObject(bucketName, objectName, cb) {
+  removeObject(bucketName, objectName, removeOpts={} , cb) {
+
     if (!isValidBucketName(bucketName)) {
       throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
     }
     if (!isValidObjectName(objectName)) {
       throw new errors.InvalidObjectNameError(`Invalid object name: ${objectName}`)
     }
+    //backward compatibility
+    if (isFunction(removeOpts)) {
+      cb = removeOpts
+      removeOpts = {}
+    }
     if (!isFunction(cb)) {
       throw new TypeError('callback should be of type "function"')
     }
-    var method = 'DELETE'
-    this.makeRequest({method, bucketName, objectName}, '', 204, '', false, cb)
+
+    const method = 'DELETE'
+    const query = querystring.stringify( removeOpts )
+
+    let requestOptions = {method, bucketName,objectName}
+    if(query){
+      requestOptions['query']=query
+    }
+
+    this.makeRequest(requestOptions, '', 204, '', false, cb)
   }
 
   // Remove all the objects residing in the objectsList.


### PR DESCRIPTION
Remove object with object version in request

This PR modifies the existing `removeObject` method to add support for `versionId` support. It is updated to be _backward compatible_
 

This depends on #891. But can be tested independently  using `mc` to enable/disable versioning and by uploading objects

TODO:

- [ ] add functional tests