### PR TITLE
Adds x-amz-security-token into the formData

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1779,6 +1779,7 @@ export class Client {
 
       if (this.sessionToken) {
         postPolicy.policy.conditions.push(['eq', '$x-amz-security-token', this.sessionToken])
+        postPolicy.formData['x-amz-security-token'] = this.sessionToken
       }
 
       var policyBase64 = Buffer.from(JSON.stringify(postPolicy.policy)).toString('base64')


### PR DESCRIPTION
Fixes #898 

Adds the missing `x-amz-security-token` into the formData, returned from presignedPostPolicy.