### PR TITLE
Bucket/Object Tags feature with versioning support included

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,6 +178,9 @@ The full API Reference is available here.
 * [list-incomplete-uploads.js](https://github.com/minio/minio-js/blob/master/examples/list-incomplete-uploads.js)
 * [get-bucket-versioning.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-versioning.js)
 * [set-bucket-versioning.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-versioning.js)
+* [set-bucket-tagging.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-tagging.js)
+* [get-bucket-tagging.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-tagging.js)
+* [remove-bucket-tagging.js](https://github.com/minio/minio-js/blob/master/examples/remove-bucket-tagging.js)
 * [get-object-lock-config.js](https://github.com/minio/minio-js/blob/master/examples/get-object-lock-config.js)
 * [set-object-lock-config.js](https://github.com/minio/minio-js/blob/master/examples/set-object-lock-config.js)
 
@@ -195,6 +198,9 @@ The full API Reference is available here.
 * [stat-object.js](https://github.com/minio/minio-js/blob/master/examples/stat-object.js)
 * [get-object-retention.js](https://github.com/minio/minio-js/blob/master/examples/get-object-retention.js)
 * [put-object-retention.js](https://github.com/minio/minio-js/blob/master/examples/put-object-retention.js)
+* [put-object-tagging.js](https://github.com/minio/minio-js/blob/master/examples/put-object-tagging.js)
+* [get-object-tagging.js](https://github.com/minio/minio-js/blob/master/examples/get-object-tagging.js)
+* [remove-object-tagging.js](https://github.com/minio/minio-js/blob/master/examples/remove-object-tagging.js)
 
 #### Full Examples : Presigned Operations
 * [presigned-getobject.js](https://github.com/minio/minio-js/blob/master/examples/presigned-getobject.js)

--- a/docs/API.md
+++ b/docs/API.md
@@ -1198,6 +1198,8 @@ minioClient.getObjectRetention('bucketname', 'bucketname', { versionId: "my-vers
 
 <a name="putObjectTagging"></a>
 ### putObjectTagging(bucketName, objectName, tags[, putOpts, callback])
+<a name="setObjectTagging"></a>
+### setObjectTagging(bucketName, objectName, tags[, putOpts, callback])
 
 Put Tags on an Object
 
@@ -1213,7 +1215,7 @@ __Parameters__
 
 __Example__
 ```js
-minioClient.putObjectTagging('bucketname','object-name', tags, function (err){
+minioClient.setObjectTagging('bucketname','object-name', tags, function (err){
   if (err) {
     return console.log(err)
   }
@@ -1225,7 +1227,7 @@ __Example 1__
 Put tags on a version of an object.
 
 ```js
-minioClient.putObjectTagging('bucketname','object-name', tags, { versionId: "my-version-id" }, function (err){
+minioClient.setObjectTagging('bucketname','object-name', tags, { versionId: "my-version-id" }, function (err){
   if (err) {
     return console.log(err)
   }

--- a/docs/API.md
+++ b/docs/API.md
@@ -521,7 +521,7 @@ __Parameters__
 | Param  |  Type | Description  |
 | ---| ---|---|
 | `bucketname`  | _string_  |  Name of the bucket. |
-|`callback(err, tags)` | _function_ | Callback is called with `err` in case of error.|
+|`callback(err, tagsList)` | _function_ | Callback is called with `err` in case of error.|
 
 __Example__
 ```js
@@ -1076,7 +1076,7 @@ objectsStream.on('end', function() {
 
 ```
 
-__Example 1__
+__Example1__
 
 With versioning Support 
 
@@ -1197,7 +1197,7 @@ minioClient.getObjectRetention('bucketname', 'bucketname', { versionId: "my-vers
 ```
 
 <a name="putObjectTagging"></a>
-### putObjectTagging(bucketName, objectName, tags [putOpts, callback])
+### putObjectTagging(bucketName, objectName, tags[, putOpts, callback])
 
 Put Tags on an Object
 
@@ -1208,12 +1208,12 @@ __Parameters__
 | `bucketname`  | _string_  |  Name of the bucket. |
 | `objectName`  | _string_  |  Name of the object. |
 | `tags`  | _object_  |  Tags map Configuration e.g: `{<tag-key-1>:<tag-value-1>}` |
-| `putOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+| `putOpts`  | _object_  | Default is {}.  e.g `{versionId:"my-version-id"}`. (Optional)|
 |`callback(err)` | _function_ | Callback is called with `err` in case of error.|
 
 __Example__
 ```js
-minioClient.putObjectTagging('bucketname','object-name',tags, function (err){
+minioClient.putObjectTagging('bucketname','object-name', tags, function (err){
   if (err) {
     return console.log(err)
   }
@@ -1222,7 +1222,7 @@ minioClient.putObjectTagging('bucketname','object-name',tags, function (err){
 ```
 
 <a name="removeObjectTagging"></a>
-### removeObjectTagging(bucketName, objectName, [removeOpts, callback])
+### removeObjectTagging(bucketName, objectName[, removeOpts, callback])
 
 Remove Tags on an Object
 
@@ -1232,7 +1232,7 @@ __Parameters__
 | ---| ---|---|
 | `bucketname`  | _string_  |  Name of the bucket. |
 | `objectName`  | _string_  |  Name of the object. |
-| `removeOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+| `removeOpts`  | _object_  |  Defaults to {}. e.g `{versionId:"my-version-id"}`. (Optional) |
 |`callback(err)` | _function_ | Callback is called with `err` in case of error.|
 
 __Example__
@@ -1246,11 +1246,11 @@ minioClient.removeObjectTagging('bucketname','object-name', function (err){
 ```
 
 
-__Example 1__
+__Example1__
 Remove tags on a version of an object.
 
 ```js
-minioClient.removeObjectTagging('bucketname','object-name',{versionId:"my-object-version-id"}, function (err){
+minioClient.removeObjectTagging('bucketname', 'object-name', {versionId:"my-object-version-id"}, function (err){
   if (err) {
     return console.log(err)
   }
@@ -1259,7 +1259,7 @@ minioClient.removeObjectTagging('bucketname','object-name',{versionId:"my-object
 ```
 
 <a name="getObjectTagging"></a>
-### getObjectTagging(bucketName, objectName,[getOpts, callback])
+### getObjectTagging(bucketName, objectName[, getOpts, callback])
 
 Get Tags of an Object
 
@@ -1269,29 +1269,29 @@ __Parameters__
 | ---| ---|---|
 | `bucketname`  | _string_  |  Name of the bucket. |
 | `objectName`  | _string_  |  Name of the object. |
-| `getOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+| `getOpts`  | _object_  | Defaults to {}. e.g `{versionId:"my-version-id"}`. (Optional) |
 |`callback(err)` | _function_ | Callback is called with `err` in case of error.|
 
 __Example__
 ```js
-minioClient.getObjectTagging('bucketname', 'object-name', function (err){
+minioClient.getObjectTagging('bucketname', 'object-name', function (err, tagsList){
   if (err) {
     return console.log(err)
   }
-  console.log("Success")
+  console.log("Success", tagsList)
 })
 ```
 
 
-__Example 1__
+__Example1__
 Get tags on a version of an object.
 
 ```js
-minioClient.getObjectTagging('bucketname', 'object-name', {versionId:"my-object-version-id"}, function (err){
+minioClient.getObjectTagging('bucketname', 'object-name', {versionId:"my-object-version-id"}, function (err, tagsList){
   if (err) {
     return console.log(err)
   }
-  console.log("Success")
+  console.log("Success", tagsList)
 })
 ```
 
@@ -1319,7 +1319,7 @@ __Parameters__
 |`callback(err, presignedUrl)` | _function_ | Callback function is called with non `null` err value in case of error. `presignedUrl` will be the URL using which the object can be downloaded using GET request. If no callback is passed, a `Promise` is returned. |
 
 
-__Example 1__
+__Example1__
 
 
 ```js
@@ -1332,7 +1332,7 @@ minioClient.presignedUrl('GET', 'mybucket', 'hello.txt', 24*60*60, function(err,
 ```
 
 
-__Example 2__
+__Example2__
 
 
 ```js

--- a/docs/API.md
+++ b/docs/API.md
@@ -38,11 +38,12 @@ var s3Client = new Minio.Client({
 | [`listIncompleteUploads`](#listIncompleteUploads) |  [`statObject`](#statObject) |
 | [`getBucketVersioning`](#getBucketVersioning)    |  [`removeObject`](#removeObject)    |
 | [`setBucketVersioning`](#setBucketVersioning)     |  [`removeObjects`](#removeObjects)    |
-|  | [`removeIncompleteUpload`](#removeIncompleteUpload)  |
-|  | [`putObjectRetention`](#putObjectRetention)  |
-|  | [`getObjectRetention`](#getObjectRetention)  |
-
-
+| [`setBucketTagging`](#setBucketTagging)       | [`removeIncompleteUpload`](#removeIncompleteUpload)  |
+| [`removeBucketTagging`](#removeBucketTagging)  | [`putObjectRetention`](#putObjectRetention)  |
+| [`getBucketTagging`](#getBucketTagging)       | [`getObjectRetention`](#getObjectRetention)  |
+|    |  [`putObjectTagging`](#putObjectTagging)    |
+|    |  [`removeObjectTagging`](#removeObjectTagging)    |
+|    |  [`getObjectTagging`](#getObjectTagging)    |
 
 
 ## 1.  Constructor
@@ -462,6 +463,73 @@ minioClient.setBucketVersioning('bucketname',versioningConfig, function (err){
     return console.log(err)
   }
   console.log("Success")
+})
+```
+
+<a name="setBucketTagging"></a>
+### setBucketTagging(bucketName, tags, callback)
+
+Set Tags on a Bucket
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+| `tags`  | _object_  |  Tags map Configuration e.g: `{<tag-key-1>:<tag-value-1>}` |
+|`callback(err)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.setBucketTagging('bucketname',tags, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+<a name="removeBucketTagging"></a>
+### removeBucketTagging(bucketName, callback)
+
+Remove Tags on a Bucket
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+|`callback(err)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.removeBucketTagging('bucketname', function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+<a name="getBucketTagging"></a>
+### getBucketTagging(bucketName, callback)
+
+Remove Tags on a Bucket
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+|`callback(err, tags)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.getBucketTagging('bucketname', function (err, tagsList){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success",tagsList)
 })
 ```
 
@@ -1125,6 +1193,105 @@ minioClient.getObjectRetention('bucketname', 'bucketname', { versionId: "my-vers
     return console.log(err)
   }
   console.log(res)
+})
+```
+
+<a name="putObjectTagging"></a>
+### putObjectTagging(bucketName, objectName, tags [putOpts, callback])
+
+Put Tags on an Object
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+| `objectName`  | _string_  |  Name of the object. |
+| `tags`  | _object_  |  Tags map Configuration e.g: `{<tag-key-1>:<tag-value-1>}` |
+| `putOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+|`callback(err)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.putObjectTagging('bucketname','object-name',tags, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+<a name="removeObjectTagging"></a>
+### removeObjectTagging(bucketName, objectName, [removeOpts, callback])
+
+Remove Tags on an Object
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+| `objectName`  | _string_  |  Name of the object. |
+| `removeOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+|`callback(err)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.removeObjectTagging('bucketname','object-name', function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+
+__Example 1__
+Remove tags on a version of an object.
+
+```js
+minioClient.removeObjectTagging('bucketname','object-name',{versionId:"my-object-version-id"}, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+<a name="getObjectTagging"></a>
+### getObjectTagging(bucketName, objectName,[getOpts, callback])
+
+Get Tags of an Object
+
+__Parameters__
+
+| Param  |  Type | Description  |
+| ---| ---|---|
+| `bucketname`  | _string_  |  Name of the bucket. |
+| `objectName`  | _string_  |  Name of the object. |
+| `getOpts`  | _object_  | (Optional) e.g `{versionId:"my-version-id"}`. |
+|`callback(err)` | _function_ | Callback is called with `err` in case of error.|
+
+__Example__
+```js
+minioClient.getObjectTagging('bucketname', 'object-name', function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
+
+__Example 1__
+Get tags on a version of an object.
+
+```js
+minioClient.getObjectTagging('bucketname', 'object-name', {versionId:"my-object-version-id"}, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
 })
 ```
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -1221,6 +1221,18 @@ minioClient.putObjectTagging('bucketname','object-name', tags, function (err){
 })
 ```
 
+__Example 1__
+Put tags on a version of an object.
+
+```js
+minioClient.putObjectTagging('bucketname','object-name', tags, { versionId: "my-version-id" }, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+```
+
 <a name="removeObjectTagging"></a>
 ### removeObjectTagging(bucketName, objectName[, removeOpts, callback])
 

--- a/examples/get-bucket-tagging.js
+++ b/examples/get-bucket-tagging.js
@@ -1,0 +1,35 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+
+s3Client.getBucketTagging('bucketname', function (err, tagsList){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success", tagsList)
+})

--- a/examples/get-object-tagging.js
+++ b/examples/get-object-tagging.js
@@ -1,0 +1,44 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+
+s3Client.getObjectTagging('bucketname', "objectName", function (err, tagsList){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success",tagsList)
+})
+
+//Get tags on a version of an object.
+
+s3Client.getObjectTagging('bucketname', "objectName", { versionId: "" }, function (err, tagsList){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success",tagsList)
+})

--- a/examples/put-object-tagging.js
+++ b/examples/put-object-tagging.js
@@ -1,0 +1,44 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+var tagsMap = {"tagkey":"tagvalue"}
+
+s3Client.putObjectTagging('bucketname', "object-name", tagsMap, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+
+//Put tags on a version of an object
+s3Client.putObjectTagging('bucketname', "object-name", tagsMap, { versionId: "my-version-id" }, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})

--- a/examples/remove-bucket-tagging.js
+++ b/examples/remove-bucket-tagging.js
@@ -1,0 +1,34 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+s3Client.removeBucketTagging('bucketname', function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})

--- a/examples/remove-object-tagging.js
+++ b/examples/remove-object-tagging.js
@@ -1,0 +1,42 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+s3Client.removeObjectTagging('bucketname', "object-name", function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})
+
+//remove tags on a version of an object
+s3Client.removeObjectTagging('bucketname', 'object-name', { versionId: "my-object-version-id" }, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})

--- a/examples/set-bucket-tagging.js
+++ b/examples/set-bucket-tagging.js
@@ -1,0 +1,36 @@
+
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2021 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
+// dummy values, please replace them with original values.
+
+var Minio = require('minio')
+
+var s3Client = new Minio.Client({
+  endPoint: 's3.amazonaws.com',
+  accessKey: 'YOUR-ACCESSKEYID',
+  secretKey: 'YOUR-SECRETACCESSKEY'
+})
+
+var tagsMap = {"tagkey":"tagvalue"}
+
+s3Client.setBucketTagging('bucketname', tagsMap, function (err){
+  if (err) {
+    return console.log(err)
+  }
+  console.log("Success")
+})

--- a/examples/set-object-tagging.js
+++ b/examples/set-object-tagging.js
@@ -28,7 +28,7 @@ var s3Client = new Minio.Client({
 
 var tagsMap = {"tagkey":"tagvalue"}
 
-s3Client.putObjectTagging('bucketname', "object-name", tagsMap, function (err){
+s3Client.setObjectTagging('bucketname', "object-name", tagsMap, function (err){
   if (err) {
     return console.log(err)
   }
@@ -36,7 +36,7 @@ s3Client.putObjectTagging('bucketname', "object-name", tagsMap, function (err){
 })
 
 //Put tags on a version of an object
-s3Client.putObjectTagging('bucketname', "object-name", tagsMap, { versionId: "my-version-id" }, function (err){
+s3Client.setObjectTagging('bucketname', "object-name", tagsMap, { versionId: "my-version-id" }, function (err){
   if (err) {
     return console.log(err)
   }

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2413,6 +2413,7 @@ export class Client {
     if(objectName){
       requestOptions['objectName']=objectName
     }
+    // FIXME: This is a hack and it will be updated when server side is fixed to send the correct '204' status code
     this.makeRequest(requestOptions, '', 200, '', true, cb)
   }
 

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2368,7 +2368,7 @@ export class Client {
    *  putOpts _object_ (Optional) e.g {versionId:"my-object-version-id"},
    * `cb(error)` _function_ - callback function with `err` as the error argument. `err` is null if the operation is successful.
    */
-  putObjectTagging(bucketName, objectName, tags, putOpts={}, cb){
+  setObjectTagging(bucketName, objectName, tags, putOpts={}, cb){
     if (!isValidBucketName(bucketName)) {
       throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
     }
@@ -2743,7 +2743,7 @@ Client.prototype.setBucketVersioning=promisify((Client.prototype.setBucketVersio
 Client.prototype.setBucketTagging=promisify((Client.prototype.setBucketTagging))
 Client.prototype.removeBucketTagging=promisify((Client.prototype.removeBucketTagging))
 Client.prototype.getBucketTagging=promisify((Client.prototype.getBucketTagging))
-Client.prototype.putObjectTagging=promisify((Client.prototype.putObjectTagging))
+Client.prototype.setObjectTagging=promisify((Client.prototype.setObjectTagging))
 Client.prototype.removeObjectTagging=promisify((Client.prototype.removeObjectTagging))
 Client.prototype.getObjectTagging=promisify((Client.prototype.getObjectTagging))
 Client.prototype.setObjectLockConfig=promisify((Client.prototype.setObjectLockConfig))

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2364,8 +2364,8 @@ export class Client {
    * __Arguments__
    * bucketName _string_
    * objectName _string_
+   *  * tags _object_ of the form {'<tag-key-1>':'<tag-value-1>','<tag-key-2>':'<tag-value-2>'}
    *  putOpts _object_ (Optional) e.g {versionId:"my-object-version-id"},
-   * tags _object_ of the form {'<tag-key-1>':'<tag-value-1>','<tag-key-2>':'<tag-value-2>'}
    * `cb(error)` _function_ - callback function with `err` as the error argument. `err` is null if the operation is successful.
    */
   putObjectTagging(bucketName, objectName, tags, putOpts={}, cb){

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2350,8 +2350,8 @@ export class Client {
     if(!isObject(tags)){
       throw new errors.InvalidArgumentError('tags should be of type "object"')
     }
-    if(Object.keys(tags).length > 50){
-      throw new errors.InvalidArgumentError('maximum tags allowed is 50"')
+    if(Object.keys(tags).length > 10){
+      throw new errors.InvalidArgumentError('maximum tags allowed is 10"')
     }
     if (!isFunction(cb)) {
       throw new errors.InvalidArgumentError('callback should be of type "function"')
@@ -2384,8 +2384,8 @@ export class Client {
     if(!isObject(tags)){
       throw new errors.InvalidArgumentError('tags should be of type "object"')
     }
-    if(Object.keys(tags).length > 50){
-      throw new errors.InvalidArgumentError('Maximum tags allowed is 50"')
+    if(Object.keys(tags).length > 10){
+      throw new errors.InvalidArgumentError('Maximum tags allowed is 10"')
     }
 
     if (!isFunction(cb)) {

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -218,6 +218,10 @@ export function  bucketVersioningTransformer(){
   return getConcater(xmlParsers.parseBucketVersioningConfig)
 }
 
+export function getTagsTransformer() {
+  return getConcater( xmlParsers.parseTagging)
+}
+
 export function  objectLockTransformer(){
   return getConcater(xmlParsers.parseObjectLockConfig)
 }

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -467,7 +467,17 @@ export function parseBucketVersioningConfig(xml){
 
 export function parseTagging(xml){
   const xmlObj = parseXml(xml)
-  return xmlObj
+  let result =[]
+  if(xmlObj.Tagging && xmlObj.Tagging.TagSet&& xmlObj.Tagging.TagSet.Tag){
+    const tagResult = xmlObj.Tagging.TagSet.Tag
+    //if it is a single tag convert into an array so that the return value is always an array.
+    if(isObject(tagResult)){
+      result.push(tagResult)
+    }else{
+      result = tagResult
+    }
+  }
+  return result
 }
 
 

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -18,8 +18,8 @@ import fxp from 'fast-xml-parser'
 import _ from 'lodash'
 import * as errors from './errors.js'
 import {
-  isObject, 
-  sanitizeETag, 
+  isObject,
+  sanitizeETag,
   RETENTION_VALIDITY_UNITS
 } from "./helpers"
 
@@ -463,6 +463,11 @@ export function parseListObjectsV2WithMetadata(xml) {
 export function parseBucketVersioningConfig(xml){
   var xmlObj = parseXml(xml)
   return xmlObj.VersioningConfiguration
+}
+
+export function parseTagging(xml){
+  const xmlObj = parseXml(xml)
+  return xmlObj
 }
 
 

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -28,7 +28,7 @@ const assert = chai.assert
 const superagent = require('superagent')
 const uuid = require("uuid")
 const step = require("mocha-steps").step
-import { getVersionId, isObject } from "../../../dist/main/helpers"
+import { getVersionId, isArray } from "../../../dist/main/helpers"
 let minio
 
 try {
@@ -1655,7 +1655,7 @@ describe('functional tests', function() {
       step(`Get tags on a bucket_bucketName:${tagsBucketName}`, done => {
         client.getBucketTagging(tagsBucketName, (err, tagList) => {
           if (err) return done(err)
-          if(isObject(tagList)) {
+          if(isArray(tagList)) {
             done()
           }
         })
@@ -1701,7 +1701,7 @@ describe('functional tests', function() {
       step(`getObjectTagging  object_bucketName:${tagsBucketName}, objectName:${tagObjName},`, done => {
         client.getObjectTagging(tagsBucketName, tagObjName, (err, tagList) => {
           if (err) return done(err)
-          if(isObject(tagList)) {
+          if(isArray(tagList)) {
             done()
           }
         })
@@ -1775,7 +1775,7 @@ describe('functional tests', function() {
         if(isVersioningSupported) {
           client.getObjectTagging(tagsVersionedBucketName, tagObjName,  {versionId:versionId},(err, tagList) => {
             if (err) return done(err)
-            if(isObject(tagList)) {
+            if(isArray(tagList)) {
               done()
             }
           })}else{

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -1692,7 +1692,7 @@ describe('functional tests', function() {
       })
 
       step(`putObjectTagging  object_bucketName:${tagsBucketName}, objectName:${tagObjName},`, done => {
-        client.putObjectTagging(tagsBucketName, tagObjName, {'test-tag-key-obj':'test-tag-value-obj'}, (err) => {
+        client.setObjectTagging(tagsBucketName, tagObjName, {'test-tag-key-obj':'test-tag-value-obj'}, (err) => {
           if (err) return done(err)
           done()
         })
@@ -1762,7 +1762,7 @@ describe('functional tests', function() {
 
       step(`Set tags on an object_bucketName:${tagsVersionedBucketName}, objectName:${tagObjName},`, done => {
         if(isVersioningSupported) {
-          client.putObjectTagging(tagsVersionedBucketName, tagObjName, {'test-tag-key-obj':'test-tag-value-obj'}, {versionId:versionId}, (err) => {
+          client.setObjectTagging(tagsVersionedBucketName, tagObjName, {'test-tag-key-obj':'test-tag-value-obj'}, {versionId:versionId}, (err) => {
             if (err) return done(err)
             done()
           })

--- a/src/test/unit/test.js
+++ b/src/test/unit/test.js
@@ -713,6 +713,206 @@ describe('Client', function() {
     })
   })
 
+
+  describe('Bucket and Object Tags APIs', () => {
+    describe('Set Bucket Tags ', () => {
+      it('should fail on null bucket', (done) => {
+        try {
+          client.setBucketTagging(null, {}, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty bucket', (done) => {
+        try {
+          client.setBucketTagging('', {}, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail if tags are more than 50', (done) => {
+        const _50_plus_key_tags={}
+        for(let i=0;i<51;i+=1){
+          _50_plus_key_tags[i]=i
+        }
+        try {
+          client.setBucketTagging('', _50_plus_key_tags, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+    })
+    describe('Get Bucket Tags', () => {
+      it('should fail on invalid bucket', (done) => {
+        try {
+          client.getBucketTagging('nv',null,  function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on null bucket', (done) => {
+        try {
+          client.getBucketTagging(null, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty bucket', (done) => {
+        try {
+          client.getBucketTagging('', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+
+    })
+    describe('Remove Bucket Tags', () => {
+      it('should fail on null object', (done) => {
+        try {
+          client.removeBucketTagging(null, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty bucket', (done) => {
+        try {
+          client.removeBucketTagging('',  function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on invalid bucket name', (done) => {
+        try {
+          client.removeBucketTagging('198.51.100.24', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+      it('should fail on invalid bucket name', (done) => {
+        try {
+          client.removeBucketTagging('xy', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+    })
+    describe('Put Object Tags', () => {
+      it('should fail on null object', (done) => {
+        try {
+          client.putObjectTagging('my-bucket-name',null, {}, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty object', (done) => {
+        try {
+          client.putObjectTagging('my-bucket-name',null, {}, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on non object tags', (done) => {
+        try {
+          client.putObjectTagging('my-bucket-name',null, 'non-obj-tag', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail if tags are more than 50 on an object', (done) => {
+        const _50_plus_key_tags={}
+        for(let i=0;i<51;i+=1){
+          _50_plus_key_tags[i]=i
+        }
+        try {
+          client.putObjectTagging('my-bucket-name',null, _50_plus_key_tags, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+    })
+    describe('Get Object Tags', () => {
+      it('should fail on invalid bucket', (done) => {
+        try {
+          client.getObjectTagging('nv',null,  function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on null object', (done) => {
+        try {
+          client.getObjectTagging('my-bucket-name',null, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty object', (done) => {
+        try {
+          client.getObjectTagging('my-bucket-name',null, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+
+    })
+    describe('Remove Object Tags', () => {
+      it('should fail on null object', (done) => {
+        try {
+          client.removeObjectTagging('my-bucket',null, function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on empty bucket', (done) => {
+        try {
+          client.removeObjectTagging('my-bucket', '',  function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+      it('should fail on invalid bucket name', (done) => {
+        try {
+          client.removeObjectTagging('198.51.100.24', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+
+      it('should fail on invalid bucket name', (done) => {
+        try {
+          client.removeObjectTagging('xy', function () {
+          })
+        } catch (e) {
+          done()
+        }
+      })
+    })
+  })
+
   describe('Object Locking APIs', ()=> {
     describe('getObjectLockConfig(bucket, callback)', () => {
       it('should fail on null bucket', (done) => {


### PR DESCRIPTION
Implement Tags on 
- Bucket
  - `setBucketTagging`
  - `removeBucketTagging`
  - `getBucketTagging`
- Object
  - `setObjectTagging`   ( Supports optional versionId)
  -  `removeObjectTagging` (Supports optional versionId)
  - `getObjectTagging` (Supports optional versionId)
  
Closes #884