### PR TITLE
Fixed sessionToken not being escaped in the query

### DIFF
--- a/src/main/signing.js
+++ b/src/main/signing.js
@@ -265,7 +265,7 @@ export function presignSignatureV4(request, accessKey, secretKey, sessionToken, 
   requestQuery.push(`X-Amz-Expires=${expires}`)
   requestQuery.push(`X-Amz-SignedHeaders=${uriEscape(signedHeaders.join(';').toLowerCase())}`)
   if (sessionToken) {
-    requestQuery.push(`X-Amz-Security-Token=${sessionToken}`)
+    requestQuery.push(`X-Amz-Security-Token=${uriEscape(sessionToken)}`)
   }
 
   var resource = request.path.split('?')[0]


### PR DESCRIPTION
The sessionToken (at least in AWS) is base64 encoded and may contain forward slashes, plusses etc. Without escaping it you get invalid token responses when generating pre-signed gets.