### PR TITLE
Fix multipart upload from stream with metadata

### DIFF
--- a/src/main/object-uploader.js
+++ b/src/main/object-uploader.js
@@ -60,7 +60,7 @@ export default class ObjectUploader extends Transform {
   _transform(chunk, encoding, callback) {
     this.emptyStream = false
     let method = 'PUT'
-    let headers = Object.assign({}, this.metaData, {'Content-Length': chunk.length})
+    let headers = {'Content-Length': chunk.length}
     let md5digest = ''
 
     // Calculate and set Content-MD5 header if SHA256 is not set.
@@ -75,7 +75,9 @@ export default class ObjectUploader extends Transform {
     if (this.partNumber == 1 && chunk.length < this.partSize) {
       // PUT the chunk in a single request — use an empty query.
       let options = {
-        method, headers,
+        method,
+        // Set user metadata as this is not a multipart upload
+        headers: Object.assign({}, this.metaData, headers),
         query: '',
         bucketName: this.bucketName,
         objectName: this.objectName

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -408,9 +408,9 @@ describe('functional tests', function() {
         .catch(done)
     })
 
-    step(`putObject(bucketName, objectName, stream, cb)_bucketName:${bucketName}, objectName:${_65mbObjectName}_`, done => {
+    step(`putObject(bucketName, objectName, stream, metadata, cb)_bucketName:${bucketName}, objectName:${_65mbObjectName}_`, done => {
       var stream = readableStream(_65mb)
-      client.putObject(bucketName, _65mbObjectName, stream, () => {
+      client.putObject(bucketName, _65mbObjectName, stream, metaData, () => {
         setTimeout(() => {
           if (Object.values(httpAgent.sockets).length === 0) return done()
           done(new Error('http request did not release network socket'))
@@ -471,6 +471,10 @@ describe('functional tests', function() {
       client.statObject(bucketName, _65mbObjectName, (e, stat) => {
         if (e) return done(e)
         if (stat.size !== _65mb.length) return done(new Error('size mismatch'))
+        if (`${metaData.randomstuff}` !== stat.metaData.randomstuff) return done(new Error('metadata "randomstuff" mismatch'))
+        if (`${metaData["X-Amz-Meta-Testing"]}` !== stat.metaData["testing"]) return done(new Error('metadata "testing" mismatch'))
+        if (`${metaData["Content-Type"]}` !== stat.metaData["content-type"]) return done(new Error('metadata "content-type" mismatch'))
+        if (`${metaData["Content-Language"]}` !== stat.metaData["content-language"]) return done(new Error('metadata "content-language" mismatch'))
         done()
       })
     })


### PR DESCRIPTION
With current `minio@7.0.18` when uploading a large file from a stream using `putObject()` and providing metadata will fail with error:
```
(node:15496) UnhandledPromiseRejectionWarning: S3Error: Metadata cannot be specified in this context.
    at Object.parseError (/app/node_modules/minio/dist/main/xml-parsers.js:79:11)
    at /app/node_modules/minio/dist/main/transformers.js:156:22
    at DestroyableTransform._flush (/app/node_modules/minio/dist/main/transformers.js:80:10)
    at DestroyableTransform.prefinish (/app/node_modules/readable-stream/lib/_stream_transform.js:129:10)
    at DestroyableTransform.emit (events.js:315:20)
    at prefinish (/app/node_modules/readable-stream/lib/_stream_writable.js:611:14)
    at finishMaybe (/app/node_modules/readable-stream/lib/_stream_writable.js:620:5)
    at endWritable (/app/node_modules/readable-stream/lib/_stream_writable.js:643:3)
    at DestroyableTransform.Writable.end (/app/node_modules/readable-stream/lib/_stream_writable.js:571:22)
    at IncomingMessage.onend (_stream_readable.js:684:10)
```
Same issue as #743 but I think it fixed `fPutObject()`. this issue fixes `putObject()`.

Example code:
```typescript
import minioClient from './minio/client';
import { S3_BUCKET_NAME } from './util/config';
import { createReadStream } from 'fs';

(async () => {
  const stream = createReadStream('/home/petslane/Desktop/VID_20181224_203254.mp4');
  await minioClient().putObject(
    S3_BUCKET_NAME,
    'test.mp4',
    stream,
    {
      'my-metadata': 'data',
    },
  );
})();
```

```
$ ./mc stat xxx/bucket/test.mp4
Name      : test.mp4
Date      : 2021-08-11 15:36:42 EEST 
Size      : 623 MiB 
ETag      : 57497455a24df914d1f438a18f817a05-2 
Type      : file 
Metadata  :
  Content-Type          : binary/octet-stream 
  X-Amz-Meta-My-Metadata: data 
```

refs #743 #744
