### PR TITLE
Fix request md5 for tagging

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "dependencies": {
     "async": "^3.1.0",
     "block-stream2": "^2.0.0",
+    "browser-or-node": "^1.3.0",
     "es6-error": "^4.1.1",
     "fast-xml-parser": "^3.17.5",
     "ipaddr.js": "^2.0.1",

--- a/src/main/helpers.js
+++ b/src/main/helpers.js
@@ -16,8 +16,9 @@
 
 import stream from 'stream'
 import mime from 'mime-types'
-var Crypto = require('crypto')
+var Crypto = require('crypto-browserify')
 const ipaddr = require('ipaddr.js')
+import { isBrowser } from "browser-or-node"
 
 // Returns a wrapper function that will promisify a given callback function.
 // It will preserve 'this'.
@@ -387,13 +388,18 @@ export const LEGAL_HOLD_STATUS={
 }
 
 const objectToBuffer = (payload) =>{
-  const payloadBuf = Buffer.from(Buffer.from(JSON.stringify(payload)))
+  const payloadBuf = Buffer.from(Buffer.from(payload))
   return payloadBuf
 }
 
 export const toMd5=(payload)=>{
-  return Crypto.createHash('md5').update(objectToBuffer(payload)).digest().toString('base64')
+  let payLoadBuf = objectToBuffer(payload)
+  // use string from browser and buffer from nodejs
+  // browser support is tested only against minio server
+  payLoadBuf = isBrowser ? payLoadBuf.toString() : payLoadBuf 
+  return Crypto.createHash('md5').update(payLoadBuf).digest().toString('base64')
 }
+
 export const toSha256=(payload)=>{
   return Crypto.createHash('sha256').update(payload).digest('hex')
 }

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -2353,6 +2353,7 @@ export class Client {
     const builder = new xml2js.Builder({ headless:true,renderOpts:{'pretty':false},})
     let payload = builder.buildObject(taggingConfig)
     payload = encoder.encode(payload)
+    headers['Content-MD5'] = toMd5(payload)
 
     const requestOptions = { method, bucketName, query, headers }
 


### PR DESCRIPTION
Fixes #964

- Fix broken md5 calculation for tagging requests (S3)

Tested against:

- [x] S3
- [x] MinIO Server ( Local/ play)