### PR TITLE
fix mint tests import failure for helpers

### DIFF
--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -28,7 +28,14 @@ const assert = chai.assert
 const superagent = require('superagent')
 const uuid = require("uuid")
 const step = require("mocha-steps").step
-import { getVersionId, isArray } from "../../../dist/main/helpers"
+
+let helpers
+try{
+  helpers=  require("../../../dist/main/helpers")
+}catch (err){
+  helpers = require('minio/dist/main/helpers')
+}
+
 let minio
 
 try {
@@ -36,6 +43,8 @@ try {
 } catch (err) {
   minio = require('minio')
 }
+
+const { getVersionId, isArray } = helpers
 
 require('source-map-support').install()
 


### PR DESCRIPTION


Install `minio` package globally (npm install -g minio) and swap the imports to test locally 

<summary> Local test code </summary>

<details>

replace Line numbers 32-37  with the following because during development the import should be from within package.

```
let helpers
try{
 helpers = require('minio/dist/main/helpers')
}catch (err){
  helpers=  require("../../../dist/main/helpers")
}
```

</details>