### PR TITLE
Mint Test file name to object name fix

### DIFF
--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -1335,7 +1335,7 @@ describe('functional tests', function() {
   describe('Versioning tests on a buckets', function () {
     //Isolate the bucket/object for easy debugging and tracking.
     const  versionedBucketName = "minio-js-test-version-" + uuid.v4()
-    const versioned_100kbObjectName = 'datafile-versioned-100-kB'
+    const versioned_100kbObjectName = 'datafile-100-kB'
     const versioned_100kb_Object = dataDir ? fs.readFileSync(dataDir + '/' + versioned_100kbObjectName) : Buffer.alloc(100 * 1024, 0)
 
     before((done) => client.makeBucket(versionedBucketName, '', done))
@@ -1385,7 +1385,7 @@ describe('functional tests', function() {
   describe('Versioning tests on a buckets: getObject, fGetObject, getPartialObject, putObject, removeObject with versionId support', function () {
     //Isolate the bucket/object for easy debugging and tracking.
     const  versionedBucketName = "minio-js-test-version-" + uuid.v4()
-    const versioned_100kbObjectName = 'datafile-versioned-100-kB'
+    const versioned_100kbObjectName = 'datafile-100-kB'
     const versioned_100kb_Object = dataDir ? fs.readFileSync(dataDir + '/' + versioned_100kbObjectName) : Buffer.alloc(100 * 1024, 0)
 
     before((done) => client.makeBucket(versionedBucketName, '', done))
@@ -1482,7 +1482,7 @@ describe('functional tests', function() {
   describe('Versioning Supported listObjects', function() {
     const  versionedBucketName = "minio-js-test-version-list" + uuid.v4()
     const prefixName  = "Prefix1"
-    const versionedObjectName ="datafile-versioned-list-100-kB"
+    const versionedObjectName ="datafile-100-kB"
     const objVersionIdCounter = [1,2,3,4,5]// This should track adding 5 versions of the same object.
     let listObjectsNum = objVersionIdCounter.length
     let objArray = []
@@ -1574,7 +1574,7 @@ describe('functional tests', function() {
   describe('Versioning tests on a bucket for Deletion of Multiple versions', function () {
     //Isolate the bucket/object for easy debugging and tracking.
     const  versionedBucketName = "minio-js-test-version-" + uuid.v4()
-    const versioned_100kbObjectName = 'datafile-versioned-100-kB'
+    const versioned_100kbObjectName = 'datafile-100-kB'
     const versioned_100kb_Object = dataDir ? fs.readFileSync(dataDir + '/' + versioned_100kbObjectName) : Buffer.alloc(100 * 1024, 0)
 
     before((done) => client.makeBucket(versionedBucketName, '', done))
@@ -1692,7 +1692,7 @@ describe('functional tests', function() {
     after((done) => client.removeBucket(tagsBucketName, done))
 
 
-    const tagObjName = 'datafile-tags-100-kB'
+    const tagObjName = 'datafile-100-kB'
     const tagObject = Buffer.alloc(100 * 1024, 0)
 
 
@@ -1742,7 +1742,7 @@ describe('functional tests', function() {
     after((done) => client.removeBucket(tagsVersionedBucketName, done))
 
 
-    const tagObjName = 'datafile-versioned-100-kB'
+    const tagObjName = 'datafile-100-kB'
     const tagObject = Buffer.alloc(100 * 1024, 0)
     let isVersioningSupported=false
     let versionId=null
@@ -2264,7 +2264,7 @@ describe('functional tests', function() {
     after((done) => client.removeBucket(encBucketName, done))
 
 
-    const encObjName = 'datafile-to-encrypt-100-kB'
+    const encObjName = 'datafile-100-kB'
     const encObjFileContent = Buffer.alloc(100 * 1024, 0)
     let isEncryptionSupported = false
 


### PR DESCRIPTION
Mint:  Test file name ( object name) fix . 

```
(1/1) Running minio-js tests ... FAILED in 0 seconds

Error: ENOENT: no such file or directory, open '/mint/data/datafile-versioned-100-kB'
    at Object.openSync (fs.js:497:3)
    at Object.readFileSync (fs.js:393:35)
```
