### PR TITLE
Fix copy object request

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1210,7 +1210,7 @@ export class Client {
     }
 
     var headers = {}
-    headers['x-amz-copy-source'] = uriEscape(srcObject)
+    headers['x-amz-copy-source'] = uriResourceEscape(srcObject)
 
     if (conditions !== null) {
       if (conditions.modified !== "") {


### PR DESCRIPTION
Fixes #985

With this fix the copyObject method can be used as explained in the examples