### PR TITLE
Updated maximum node version to 18

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node_version: [12.x, 14.x, 16.x, 17.x]
+        node_version: [12.x, 14.x, 16.x, 17.x, 18.x]
         os: [windows-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node_version: [12.x, 14.x, 16.x, 17.x]
+        node_version: [12.x, 14.x, 16.x, 17.x, 18.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://min.io"
   },
   "engines": {
-    "node": ">8  <=17"
+    "node": ">8  <=18"
   },
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
## What does this do?

This  PR updates max required version to be node 18 as there is an incompatibility with Node 17.3.1 & Node 16.14.0
<img width="860" alt="Screen Shot 2022-04-25 at 18 54 10" src="https://user-images.githubusercontent.com/33497058/165192919-17b01538-5581-400a-a875-ff329c3e852f.png">
<img width="835" alt="Screen Shot 2022-04-25 at 18 54 01" src="https://user-images.githubusercontent.com/33497058/165192923-57c26c9f-c79e-45d4-a0ea-ca527f0ed398.png">



