### PR TITLE
Fix composeObject error for aws non-versioned bucket

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -3258,9 +3258,13 @@ export class Client {
     }
 
     const getStatOptions = (srcConfig) =>{
-      return {
-        versionId: srcConfig.VersionID
+      let statOpts = {}
+      if(!_.isEmpty(srcConfig.VersionID)) {
+        statOpts= {
+          versionId: srcConfig.VersionID
+        }
       }
+      return statOpts
     }
     const srcObjectSizes=[]
     let totalSize=0


### PR DESCRIPTION
Fix composeObject error for aws non-versioned bucket
- [x] Tested with MinIO

Tested with S3
   - [x] non versioned bucket
   - [x] version enabled bucket





Closes #1026 

S3 Error in case of un versioned bucket and no versionId is passed.

```
ERROR BODY:
{
        "code": "UnknownError",
        "amzRequestid": null,
        "amzId2": null,
        "amzBucketRegion": null
}
REQUEST: HEAD /_100-mb-file-to-test-compose.sf-part2?versionId=

```