### PR TITLE
feature: add content type prefix to post policy

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -3635,6 +3635,15 @@ export class PostPolicy {
     this.formData['Content-Type'] = type
   }
 
+  // set Content-Type prefix, i.e image/ allows any image
+  setContentTypeStartsWith(prefix) {
+    if (!prefix) {
+      throw new Error('content-type cannot be null')
+    }
+    this.policy.conditions.push(['starts-with', '$Content-Type', prefix])
+    this.formData['Content-Type'] = prefix
+  }
+
   // set minimum/maximum length of what Content-Length can be.
   setContentLengthRange(min, max) {
     if (min > max) {

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -1004,6 +1004,44 @@ describe('functional tests', function() {
       })
     })
 
+    step('presignedPostPolicy(postPolicy, cb)_postPolicy:setContentType', done => {
+      var policy = client.newPostPolicy()
+      policy.setKey(_1byteObjectName)
+      policy.setBucket(bucketName)
+      policy.setContentType('text/plain')
+
+      client.presignedPostPolicy(policy, (e, data) => {
+        if (e) return done(e)
+        var req = superagent.post(data.postURL)
+        _.each(data.formData, (value, key) => req.field(key, value))
+        req.attach('file', Buffer.from([_1byte]), 'test')
+        req.end(function(e) {
+          if (e) return done(e)
+          done()
+        })
+        req.on('error', e => done(e))
+      })
+    })
+
+    step('presignedPostPolicy(postPolicy, cb)_postPolicy:setContentTypeStartsWith', done => {
+      var policy = client.newPostPolicy()
+      policy.setKey(_1byteObjectName)
+      policy.setBucket(bucketName)
+      policy.setContentTypeStartsWith('text/')
+
+      client.presignedPostPolicy(policy, (e, data) => {
+        if (e) return done(e)
+        var req = superagent.post(data.postURL)
+        _.each(data.formData, (value, key) => req.field(key, value))
+        req.attach('file', Buffer.from([_1byte]), 'test')
+        req.end(function(e) {
+          if (e) return done(e)
+          done()
+        })
+        req.on('error', e => done(e))
+      })
+    })
+
     step('presignedPostPolicy(postPolicy)_postPolicy: null_', done => {
       client.presignedPostPolicy(null)
         .then(() => {


### PR DESCRIPTION
Hi!,

Adding a missing feature for the post policy. The use case for this is when you want to restrict the mime type by prefix. For example, `image/` should allow any image, either be `image/png` or `image/jpeg` etc

Its also missing an update in `@types/minio` if this PR goes forward.

<https://docs.aws.amazon.com/AmazonS3/latest/API/sigv4-HTTPPOSTConstructPolicy.html>
> Content-Types values for a starts-with condition that include commas are interpreted as lists. Each value in the list must meet the condition for the whole condition to pass. For example,given the following condition:
>
>["starts-with", "$Content-Type", "image/"]
>The following value would pass the condition:
>
>"image/jpg,image/png,image/gif"