### PR TITLE
fix: async callback run multiple times in fPutObject

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1007,6 +1007,15 @@ export class Client {
       cb => fs.stat(filePath, cb),
       (stats, cb) => {
         size = stats.size
+        var cbTriggered = false
+        var origCb = cb
+        cb = function () {
+          if (cbTriggered) {
+            return
+          }
+          cbTriggered = true
+          return origCb.apply(this, arguments)
+        }
         if (size > this.maxObjectSize) {
           return cb(new Error(`${filePath} size : ${stats.size}, max allowed size : 5TB`))
         }

--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1068,6 +1068,15 @@ export class Client {
         async.whilst(
           cb => { cb(null, uploadedSize < size) },
           cb => {
+            var cbTriggered = false
+            var origCb = cb
+            cb = function () {
+              if (cbTriggered) {
+                return
+              }
+              cbTriggered = true
+              return origCb.apply(this, arguments)
+            }
             var part = parts[partNumber]
             var hash = transformers.getHashSummer(this.enableSHA256)
             var length = partSize


### PR DESCRIPTION
In some error cases, the async `cb` function is called multiple(2) times in `fPutObject`.

https://github.com/minio/minio-js/blob/06e408198fb9000406cc5b2facb50a3276f81df1/src/main/minio.js#L1023-L1033

This causes the `async` library to generate an exception `Error: Callback was already called.`, crashing the process.

This PR is to fix this issue.