### PR TITLE
Post policy example update

### DIFF
--- a/examples/presigned-postpolicy.js
+++ b/examples/presigned-postpolicy.js
@@ -26,38 +26,107 @@ var s3Client = new Minio.Client({
   useSSL: true // Default is true.
 })
 
-// Construct a new postPolicy.
-var policy = s3Client.newPostPolicy()
-// Set the object name my-objectname.
-policy.setKey("my-objectname")
-// Set the bucket to my-bucketname.
-policy.setBucket("my-bucketname")
+const superagent = require('superagent')
+const _ = require('lodash')
 
-var expires = new Date
-expires.setSeconds(24 * 60 * 60 * 10) //10 days
-policy.setExpires(expires)
 
-policy.setContentLengthRange(1024, 1024*1024) // Min upload length is 1KB Max upload size is 1MB
-
-policy.setContentType('text/plain')
-
-policy.setContentDisposition('attachment; filename=text.txt')
-
-policy.setUserMetaData({
-  key: 'value'
+var s3Client = new Minio.Client({
+  useSSL:false,
+  endPoint:"localhost",
+  port:22000,
+  accessKey:"minio",
+  secretKey:"minio123"
 })
 
-s3Client.presignedPostPolicy(policy, function(e, data) {
-  if (e) return console.log(e)
-  var curl = []
-  curl.push(`curl ${data.postURL}`)
-  for (var key in data.formData) {
-    if (data.formData.hasOwnProperty(key)) {
-      var value = data.formData[key]
-      curl.push(`-F ${key}=${value}`)
+// s3Client.traceOn()
+function testViaHttpClient () {
+
+  // Construct a new postPolicy.
+  var policy = s3Client.newPostPolicy()
+  // Set the object name my-objectname.
+  policy.setKey("infra-policy-new.txt")
+  // Set the bucket to my-bucketname.
+  policy.setBucket("post-policy-test")
+
+  var expires = new Date()
+  expires.setSeconds(24 * 60 * 60 * 10) // 10 days
+  policy.setExpires(expires)
+
+  policy.setContentLengthRange(1, 1024 * 1024) // Min upload length is 1KB Max upload size is 1MB
+
+  policy.setContentTypeStartsWith('image/jpeg')
+  policy.setContentDisposition('attachment; filename=äöüex ®©µÄÆÐÕæŒƕƩǅ 01000000 0x40 \u0040 amȡȹɆple&0a!-_.*\'()&$@=;:+,?<>.pdf')
+
+  policy.setUserMetaData({
+    "sph-meta": 'sph-value',
+    "filename-meta": 'My* Docume nt.json'
+  })
+
+
+  s3Client.presignedPostPolicy(policy, (e, data) => {
+    if (e) {
+      return console.log(e)
     }
-  }
-  // Print curl command to upload files.
-  curl.push('-F file=@<FILE>')
-  console.log(curl.join(' '))
-})
+    var req = superagent.post(data.postURL)
+    _.each(data.formData, (value, key) => req.field(key, value))
+    req.attach('file', Buffer.from(Buffer.alloc(1, 0)), 'test')
+    req.end(function (e) {
+      if (e) {
+        console.log(e)
+      }
+      // s3Client.removeObject(bucketName, objectName, done)
+    })
+    req.on('error', e => {
+      console.log(e)
+    })
+  })
+
+}
+
+function generateCurl(){
+  var policy = s3Client.newPostPolicy()
+  // Set the object name my-objectname.
+  policy.setKey("Cust_Mobile_View.png")
+  // Set the bucket to my-bucketname.
+  policy.setBucket("post-policy-test")
+
+  var expires = new Date
+  expires.setSeconds(24 * 60 * 60 * 10) // 10 days
+  policy.setExpires(expires)
+
+  policy.setContentLengthRange(1, 1024*1024) // Min upload length is 1KB Max upload size is 1MB
+
+  policy.setUserMetaData({
+    "sph-meta": 'sph-value',
+    "filename-meta": 'My* Docume nt.json'
+  })
+
+  policy.setContentType('image/png')
+
+  // this seems to cause trouble in curl.
+  // while the following sends the metadata. it is stored in unexpected format in server.
+  // policy.setContentDisposition(`attachment; filename="Cust_Mobile_View.png"`)
+
+
+  s3Client.presignedPostPolicy(policy, function(e, data) {
+    if (e) return console.log(e)
+    var curl = []
+    curl.push(`curl ${data.postURL} -X POST `)
+
+    for (var key in data.formData) {
+      if (data.formData.hasOwnProperty(key)) {
+        var value = data.formData[key]
+        curl.push(`-F ${key}='${value}'`)
+      }
+    }
+    // Print curl command to upload files.
+    // curl.push('-F file=@"/Pictures/Cust_Mobile_View.png"')
+    curl.push('-F file=@"<FILE_PATH>"')
+    console.log(curl.join(' '))
+  })
+
+}
+
+testViaHttpClient()
+
+//generateCurl()


### PR DESCRIPTION
It works with http client libraries like `superagent` 

Note: Looking for ways to escape params in `curl` - Unicode characters. Not sure if it is a curl limitation.