### PR TITLE
Missing line break causing table formatting error

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -53,6 +53,7 @@ var s3Client = new Minio.Client({
 | [`setBucketReplication`](#setBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`getBucketReplication`](#getBucketReplication)       |                                                     |                                               |                                                               |                                                       |     |
 | [`removeBucketReplication`](#removeBucketReplication) |                                                     |                                               |                                                               |                                                       |     |
+
 ## 1.  Constructor
 
 <a name="MinioClient_endpoint"></a>


### PR DESCRIPTION
A missing line break between a table and header in the API.md file caused a formatting issue when publishing to the doc site.