### PR TITLE
return to avoid multiple callbacks by async

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -641,10 +641,10 @@ export class Client {
           // Retry with region returned as part of error
           this.makeRequest({method, bucketName, headers}, payload, [200], err.region, false, cb)
         } else {
-          cb && cb(err)
+          return cb && cb(err)
         }
       }
-      cb && cb(err)
+      return cb && cb(err)
     }
     this.makeRequest({method, bucketName, headers}, payload, [200], region, false, processWithRetry)
   }


### PR DESCRIPTION
fix control flow to return to avoid multiple callbacks by async

s3 gateway test run logs:
```
Gateway Server:
MINIO_ROOT_USER=<> MINIO_ROOT_PASSWORD=<> minio gateway s3 --address ":22000" --console-address ":22001"
```

[gw_test_run.txt](https://github.com/minio/minio-js/files/9429989/gw_test_run.txt)


MinIO Server 
```
MINIO_CI_CD=on MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 MINIO_KMS_SECRET_KEY=my-minio-key:OSMM+vkKUTCvQs9YL/CVMIMt43HFhkUpqJxTmGl6rYw= MINIO_ ./minio server ~/tmp/D22/d{1...4} --address ":22000" --console-address ":22001"
```
[minio_server_test-run_logs.txt](https://github.com/minio/minio-js/files/9430008/minio_server_test-run_logs.txt)


