### PR TITLE
feat: add api to enableVirtualStyleEndpoint

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -3518,6 +3518,9 @@ export class Client {
         })
     })
   }
+  enableVirtualStyleEndpoint() {
+    this.pathStyle = false;
+  }
 
   get extensions() {
     if(!this.clientExtensions)
@@ -3579,6 +3582,7 @@ Client.prototype.setObjectLegalHold=promisify(Client.prototype.setObjectLegalHol
 Client.prototype.getObjectLegalHold=promisify(Client.prototype.getObjectLegalHold)
 Client.prototype.composeObject = promisify(Client.prototype.composeObject)
 Client.prototype.selectObjectContent=promisify(Client.prototype.selectObjectContent)
+Client.prototype.enableVirtualStyleEndpoint=promisify(Client.prototype.enableVirtualStyleEndpoint)
 
 export class CopyConditions {
   constructor() {


### PR DESCRIPTION
New to use [aliyun oss](https://help.aliyun.com/document_detail/31817.html). With ak\sk\endpoint, the aliyun oss server always response with error: `SecondLevelDomainForbidden`。I need to  add api to support virtual_style_endpoint like [minio python sdk](https://docs.min.io/docs/python-client-quickstart-guide.html). 
![image](https://user-images.githubusercontent.com/6478745/188354004-a81df533-8945-4695-838b-87f90c119774.png)

if without this api, developer must specify `pathStyle=false` when init minio client, and this api is ambiguous.
![image](https://user-images.githubusercontent.com/6478745/188354234-5a5eecc3-8bb1-4dbe-9039-20a8276ec5d8.png)


with this api, it's will be clear for developer
![image](https://user-images.githubusercontent.com/6478745/188354278-3a16cc17-800b-4a14-a891-5a7fa1b186fc.png)

