### PR TITLE
Update node version to node19

### DIFF
--- a/.github/workflows/nodejs-windows.yml
+++ b/.github/workflows/nodejs-windows.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node_version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node_version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
         os: [windows-latest]
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       max-parallel: 1
       matrix:
-        node_version: [12.x, 14.x, 16.x, 17.x, 18.x]
+        node_version: [12.x, 14.x, 16.x, 17.x, 18.x, 19.x]
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v1

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "url": "https://min.io"
   },
   "engines": {
-    "node": ">8  <=18"
+    "node": ">8  <=19"
   },
   "license": "Apache-2.0",
   "bugs": {


### PR DESCRIPTION
Node19 was released some weeks ago [nodejs](https://github.com/nodejs/node/blob/main/doc/changelogs/CHANGELOG_V19.md#19.0.0). It would be great to be able to use minio-js on devices with the latest release of node.