### PR TITLE
improve removeObjects api response handling

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1752,7 +1752,7 @@ export class Client {
 
     const encoder = new TextEncoder()
 
-    async.eachSeries(result.listOfList, (list, callback) => {
+    async.eachSeries(result.listOfList, (list) => {
       var objects=[]
       list.forEach(function(value){
         if (isObject(value)) {
@@ -1769,9 +1769,17 @@ export class Client {
 
       headers['Content-MD5'] = toMd5(payload)
 
-      this.makeRequest({ method, bucketName, query, headers}, payload, [200], '', false, (e) => {
-        if (e) return callback(e)
-        callback(null)
+      this.makeRequest({ method, bucketName, query, headers}, payload, [200], '', true, (e, response) => {
+        if (e) return cb(e)
+        let removeObjectsResult
+        pipesetup(response, transformers.removeObjectsTransformer())
+          .on('data', data => {
+            removeObjectsResult = data
+          })
+          .on('error', cb)
+          .on('end', () => {
+            cb(null, removeObjectsResult)
+          })
       })
     }, cb)
   }

--- a/src/main/transformers.js
+++ b/src/main/transformers.js
@@ -252,3 +252,7 @@ export function  uploadPartTransformer(){
 export function  selectObjectContentTransformer(){
   return  getConcater()
 }
+
+export function removeObjectsTransformer() {
+  return getConcater(xmlParsers.removeObjectsParser)
+}

--- a/src/main/xml-parsers.js
+++ b/src/main/xml-parsers.js
@@ -531,6 +531,15 @@ export function uploadPartParser (xml){
   return respEl
 }
 
+export function removeObjectsParser(xml){
+  const xmlObj = parseXml(xml)
+  if(xmlObj.DeleteResult && xmlObj.DeleteResult.Error){
+    // return errors as array always. as the response is object in case of single object passed in removeObjects
+    return toArray(xmlObj.DeleteResult.Error)
+  }
+  return []
+}
+
 export function parseSelectObjectContentResponse(res){
 
   // extractHeaderType extracts the first half of the header message, the header type.

--- a/src/test/functional/functional-tests.js
+++ b/src/test/functional/functional-tests.js
@@ -812,6 +812,51 @@ describe('functional tests', function () {
     })
   })
 
+  describe('Test Remove Objects Response in case of Errors', () => {
+
+    // Since functional tests are run with root credentials, it is not implemented.
+    // Test steps
+    // =============
+    // create a bucket
+    // add some objects
+    // create a  user
+    // assign the readonly policy to the user
+    // use the new user credentials to call remove objects API
+    // verify the response
+    // assign the readwrite policy to the user
+    // call remove objects API
+    // verify the response
+    // response.Error is an array
+    //   -[]- empty array indicates success for all objects
+
+    // Note: the response code is 200. so the consumer should inspect the response
+    // Sample Response format:
+    /**
+     * {
+     *     Code: 'AccessDenied',
+     *     Message: 'Access Denied.',
+     *     Key: '1.png',
+     *     VersionId: ''
+     *   }
+     *
+     *   or
+     *
+     *    {
+     *     Code: 'NoSuchVersion',
+     *     Message: 'The specified version does not exist. (invalid UUID length: 9)',
+     *     Key: '1.png',
+     *     VersionId: 'test-v-is'
+     *   }
+     */
+
+    /*
+    let readOnlyPolicy ='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:GetBucketLocation","s3:GetObject"],"Resource":["arn:aws:s3:::*"]}]}'
+    let readWritePolicy ='{"Version":"2012-10-17","Statement":[{"Effect":"Allow","Action":["s3:*"],"Resource":["arn:aws:s3:::*"]}]}'
+    */
+
+  })
+
+
   describe('presigned operations', () => {
     step(`presignedPutObject(bucketName, objectName, expires, cb)_bucketName:${bucketName}, objectName:${_1byteObjectName}, expires: 1000_`, done => {
       client.presignedPutObject(bucketName, _1byteObjectName, 1000, (e, presignedUrl) => {


### PR DESCRIPTION
Fixes #1110

Test script
The remove objects api returns 200 but response with deletion fail reasons for each object

-  A user with readonly policy can be used to simulate this 


```javascript

var s3Client = new Minio.Client({
  endPoint: 'localhost',
  accessKey: 'test-user',
  secretKey: 'minio123',
  useSSL:false,
  port:22000
})

const deleteList = [
  { name: '1.png'},
  { name: '1.png', versionId:"test-v-is"}
]

s3Client.removeObjects("test-bucket", deleteList ,(e, res) => {
  console.log("Multiple objects delete .", res)
})


```
