### PR TITLE
Fixed issue with closing files in fPutObject() function

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1018,6 +1018,7 @@ export class Client {
       cb => fs.stat(filePath, cb),
       (stats, cb) => {
         size = stats.size
+        var stream
         var cbTriggered = false
         var origCb = cb
         cb = function () {
@@ -1025,6 +1026,7 @@ export class Client {
             return
           }
           cbTriggered = true
+          if (stream) stream.destroy()
           return origCb.apply(this, arguments)
         }
         if (size > this.maxObjectSize) {
@@ -1044,7 +1046,7 @@ export class Client {
             .on('data', data => {
               var md5sum = data.md5sum
               var sha256sum = data.sha256sum
-              var stream = fs.createReadStream(filePath, options)
+              stream = fs.createReadStream(filePath, options)
               uploader(stream, size, sha256sum, md5sum, (err, objInfo) => {
                 callback(err, objInfo)
                 cb(true)
@@ -1079,6 +1081,7 @@ export class Client {
         async.whilst(
           cb => { cb(null, uploadedSize < size) },
           cb => {
+            var stream
             var cbTriggered = false
             var origCb = cb
             cb = function () {
@@ -1086,6 +1089,7 @@ export class Client {
                 return
               }
               cbTriggered = true
+              if (stream) stream.destroy()
               return origCb.apply(this, arguments)
             }
             var part = parts[partNumber]
@@ -1110,7 +1114,7 @@ export class Client {
                   return cb()
                 }
                 // part is not uploaded yet, or md5 mismatch
-                var stream = fs.createReadStream(filePath, options)
+                stream = fs.createReadStream(filePath, options)
                 uploader(uploadId, partNumber, stream, length,
                          data.sha256sum, data.md5sum, (e, objInfo) => {
                            if (e) return cb(e)


### PR DESCRIPTION
When using the fPutObject() function, in case of an error, the file opened for reading is not closed.

**How to reproduce**

1. Make a test file /tmp/test

```sh
touch /tmp/test
```

2. Create test.js

```js
const Minio = require('minio')

const client = new Minio.Client({
  useSSL: false,
  endPoint: '127.0.0.1',
  port: 9000,
  accessKey: 'minioadmin',
  secretKey: 'minioadmin'
})

setInterval(() => {
  client.fPutObject('test', 'test', '/tmp/test')
    .then(() => console.log('ok'))
    .catch(err => console.log(err))
}, 1000)
```

3. Run test.js

```sh
node test.js
```

4. Check open files for the process

```sh
lsof -p $(pgrep node)

...
node    52282 user   94r      REG                9,0        0 47450575 /tmp/test
node    52282 user   95r      REG                9,0        0 47450575 /tmp/test
node    52282 user   96r      REG                9,0        0 47450575 /tmp/test
```

When files are correctly closed they should not be in this list.