### PR TITLE
Fix string interpolation of presignedPutObject

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1946,10 +1946,10 @@ export class Client {
   // * `expiry` _number_: expiry in seconds (optional, default 7 days)
   presignedPutObject(bucketName, objectName, expires, cb) {
     if (!isValidBucketName(bucketName)) {
-      throw new errors.InvalidBucketNameError('Invalid bucket name: ${bucketName}')
+      throw new errors.InvalidBucketNameError(`Invalid bucket name: ${bucketName}`)
     }
     if (!isValidObjectName(objectName)) {
-      throw new errors.InvalidObjectNameError('Invalid object name: ${objectName}')
+      throw new errors.InvalidObjectNameError(`Invalid object name: ${objectName}`)
     }
     return this.presignedUrl('PUT', bucketName, objectName, expires, cb)
   }


### PR DESCRIPTION
When throwing error from presignedPutPbject, string interpolation is disabled and representation of user input is unavailable.
So, I fixed it to enable string interpolation.