### PR TITLE
Fixed error handling in putObject

### DIFF
--- a/src/main/minio.js
+++ b/src/main/minio.js
@@ -1211,7 +1211,7 @@ export class Client {
     // to the specified bucket and object automatically.
     let uploader = new ObjectUploader(this, bucketName, objectName, size, metaData, callback)
     // stream => chunker => uploader
-    stream.pipe(chunker).pipe(uploader)
+    pipesetup(stream, chunker, uploader)
   }
 
   // Copy the object.


### PR DESCRIPTION
Replaced simple pipes with `pipesetup` to propagate stream errors.