### PR TITLE
Update imports so tests can be run externally like mint

### DIFF
--- a/tests/functional/functional-tests.js
+++ b/tests/functional/functional-tests.js
@@ -25,19 +25,21 @@ import * as url from 'node:url'
 import async from 'async'
 import chai from 'chai'
 import _ from 'lodash'
+import { AssumeRoleProvider } from 'minio/dist/main/AssumeRoleProvider.js'
+import { CopyDestinationOptions, CopySourceOptions, DEFAULT_REGION } from 'minio/dist/main/helpers.js'
+import * as minio from 'minio/dist/main/minio.js'
 import { step } from 'mocha-steps'
 import splitFile from 'split-file'
 import superagent from 'superagent'
 import * as uuid from 'uuid'
 
-import { AssumeRoleProvider } from '../../src/AssumeRoleProvider.ts'
-import { CopyDestinationOptions, CopySourceOptions, DEFAULT_REGION } from '../../src/helpers.ts'
-import { getVersionId } from '../../src/internal/helper.ts'
-import * as minio from '../../src/minio.js'
-
 const assert = chai.assert
 
 const isWindowsPlatform = process.platform === 'win32'
+
+function getVersionId(headers = {}) {
+  return headers['x-amz-version-id'] || null
+}
 
 describe('functional tests', function () {
   this.timeout(30 * 60 * 1000)

--- a/tests/functional/jsconfig.json
+++ b/tests/functional/jsconfig.json
@@ -1,0 +1,5 @@
+{
+  "moduleResolution": "classic",
+  "allowSyntheticDefaultImports": true,
+  "exclude": ["dist/**/*", "node_modules/**/*"]
+}


### PR DESCRIPTION
Update imports so tests can be run externally like mint

How to test locally ( within this repo)
```
rm -rf dist node_modules && npm install && npm run build
SERVER_ENDPOINT="localhost:22000" ACCESS_KEY="minio" SECRET_KEY="minio123" npm run test
```


External test:
https://github.com/prakashsvmx/minio-mint-js/pull/1

