### PR TITLE
fix: cjs type definition

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "S3 Compatible Cloud Storage client",
   "main": "./dist/main/minio.js",
   "module": "./dist/esm/minio.mjs",
-  "types": "./dist/main/minio.d.ts",
   "scripts": {
     "prepare": "husky install",
     "tsc": "tsc",
@@ -21,19 +20,16 @@
   },
   "exports": {
     ".": {
-      "types": "./dist/main/minio.d.ts",
       "require": "./dist/main/minio.js",
       "default": "./dist/esm/minio.mjs"
     },
     "./dist/main/internal/*": null,
     "./dist/main/*": {
-      "types": "./dist/main/*",
       "require": "./dist/main/*",
       "default": null
     },
     "./dist/esm/internal/*": null,
     "./dist/esm/*": {
-      "types": "./dist/esm/*",
       "import": "./dist/esm/*",
       "default": null
     },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "esModuleInterop": true,
     "allowImportingTsExtensions": true,
     "declaration": true,
-    "declarationMap": true,
+    "declarationMap": false,
     "emitDeclarationOnly": true,
     "sourceMap": true,
     "outDir": "./dist/main/",


### PR DESCRIPTION
close https://github.com/minio/minio-js/issues/1166

This PR doesn't affect any other PR, can be merged separately.

Also no need to run e2e tests, it only change build script, make it rewrite import path in `.d.ts` files