### PR TITLE
fix listIncompleteUploads method returning error uploadIdMarker should be of type string

### DIFF
--- a/src/xml-parsers.js
+++ b/src/xml-parsers.js
@@ -69,7 +69,7 @@ export function parseListMultipart(xml) {
     result.nextKeyMarker = xmlobj.NextKeyMarker
   }
   if (xmlobj.NextUploadIdMarker) {
-    result.nextUploadIdMarker = xmlobj.nextUploadIdMarker
+    result.nextUploadIdMarker = xmlobj.nextUploadIdMarker || ''
   }
 
   if (xmlobj.CommonPrefixes) {


### PR DESCRIPTION
fix listIncompleteUploads method returning error uploadIdMarker should be of type string

When there are more than 1000 incomplete uploads with S3, it should successfully list all of them. 
This is not applicable in MinIO