### PR TITLE
 refactor `removeBucketReplication` api to ts

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,7 +166,7 @@ The full API Reference is available here.
 
 #### Full Examples : Bucket Operations
 
-- [list-buckets.js](https://github.com/minio/minio-js/blob/master/examples/list-buckets.js)
+- [list-buckets.mjs](https://github.com/minio/minio-js/blob/master/examples/list-buckets.mjs)
 - [list-objects.js](https://github.com/minio/minio-js/blob/master/examples/list-objects.js)
 - [list-objects-v2.js](https://github.com/minio/minio-js/blob/master/examples/list-objects-v2.js)
 - [list-objects-v2-with-metadata.js](https://github.com/minio/minio-js/blob/master/examples/list-objects-v2-with-metadata.js) (Extension)
@@ -186,7 +186,7 @@ The full API Reference is available here.
 - [set-object-lock-config.js](https://github.com/minio/minio-js/blob/master/examples/set-object-lock-config.js)
 - [set-bucket-replication.js](https://github.com/minio/minio-js/blob/master/examples/set-bucket-replication.js)
 - [get-bucket-replication.js](https://github.com/minio/minio-js/blob/master/examples/get-bucket-replication.js)
-- [remove-bucket-replication.js](https://github.com/minio/minio-js/blob/master/examples/remove-bucket-replication.js)
+- [remove-bucket-replication.mjs](https://github.com/minio/minio-js/blob/master/examples/remove-bucket-replication.mjs)
 
 #### Full Examples : File Object Operations
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -206,7 +206,7 @@ Please refer to: [list-buckets.mjs](..%2Fexamples%2Flist-buckets.mjs)
 
 ```js
 try {
-  const buckets = await s3Client.listBuckets()
+  const buckets = await minioClient.listBuckets()
   console.log('Success', buckets)
 } catch (err) {
   console.log(err.message)
@@ -581,26 +581,26 @@ minioClient.getBucketReplication('bucketname', function (err, replicationConfig)
 
 <a name="removeBucketReplication"></a>
 
-### removeBucketReplication(bucketName, callback)
+### removeBucketReplication(bucketName)
 
 Remove replication config of a Bucket
 
 **Parameters**
 
-| Param           | Type       | Description                                     |
-| --------------- | ---------- | ----------------------------------------------- |
-| `bucketName`    | _string_   | Name of the bucket.                             |
-| `callback(err)` | _function_ | Callback is called with `err` in case of error. |
+| Param        | Type     | Description         |
+| ------------ | -------- | ------------------- |
+| `bucketName` | _string_ | Name of the bucket. |
 
 **Example**
+Please refer to : [remove-bucket-replication.mjs](..%2Fexamples%2Fremove-bucket-replication.mjs)
 
 ```js
-minioClient.removeBucketReplication('bucketname', function (err, replicationConfig) {
-  if (err) {
-    return console.log(err)
-  }
+try {
+  minioClient.removeBucketReplication('source-bucket')
   console.log('Success')
-})
+} catch (err) {
+  console.log(err.message)
+}
 ```
 
 <a name="setBucketTagging"></a>

--- a/docs/API.md
+++ b/docs/API.md
@@ -596,7 +596,7 @@ Please refer to : [remove-bucket-replication.mjs](..%2Fexamples%2Fremove-bucket-
 
 ```js
 try {
-  minioClient.removeBucketReplication('source-bucket')
+  await minioClient.removeBucketReplication('source-bucket')
   console.log('Success')
 } catch (err) {
   console.log(err.message)

--- a/examples/remove-bucket-replication.mjs
+++ b/examples/remove-bucket-replication.mjs
@@ -26,7 +26,7 @@ const s3Client = new Minio.Client({
 })
 
 try {
-  s3Client.removeBucketReplication('source-bucket')
+  await s3Client.removeBucketReplication('source-bucket')
   console.log('Success')
 } catch (err) {
   console.log(err.message)

--- a/examples/remove-bucket-replication.mjs
+++ b/examples/remove-bucket-replication.mjs
@@ -17,17 +17,17 @@
 // Note: YOUR-ACCESSKEYID, YOUR-SECRETACCESSKEY and my-bucketname are
 // dummy values, please replace them with original values.
 
-var Minio = require('minio')
+import * as Minio from 'minio'
 
-var s3Client = new Minio.Client({
+const s3Client = new Minio.Client({
   endPoint: 's3.amazonaws.com',
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY',
 })
 
-s3Client.removeBucketReplication('bucketname', function (err) {
-  if (err) {
-    return console.log(err)
-  }
+try {
+  s3Client.removeBucketReplication('source-bucket')
   console.log('Success')
-})
+} catch (err) {
+  console.log(err.message)
+}

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -888,6 +888,7 @@ export class TypedClient {
     return xmlParsers.parseListBucket(xmlResult)
   }
 
+  async removeBucketReplication(bucketName: string): Promise<void>
   removeBucketReplication(bucketName: string, callback: NoResultCallback): void
   async removeBucketReplication(bucketName: string): Promise<void> {
     if (!isValidBucketName(bucketName)) {

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -887,4 +887,14 @@ export class TypedClient {
     const xmlResult = await readAsString(httpRes)
     return xmlParsers.parseListBucket(xmlResult)
   }
+
+  removeBucketReplication(bucketName: string, callback: NoResultCallback): void
+  async removeBucketReplication(bucketName: string): Promise<void> {
+    if (!isValidBucketName(bucketName)) {
+      throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
+    }
+    const method = 'DELETE'
+    const query = 'replication'
+    await this.makeRequestAsyncOmit({ method, bucketName, query }, '', [200, 204], '')
+  }
 }

--- a/src/minio.d.ts
+++ b/src/minio.d.ts
@@ -290,9 +290,6 @@ export class Client extends TypedClient {
   getBucketReplication(bucketName: string, callback: ResultCallback<ReplicationConfig>): void
   getBucketReplication(bucketName: string): Promise<ReplicationConfig>
 
-  removeBucketReplication(bucketName: string, callback: NoResultCallback): void
-  removeBucketReplication(bucketName: string): Promise<void>
-
   // Object operations
   getObject(bucketName: string, objectName: string, callback: ResultCallback<ReadableStream>): void
   getObject(bucketName: string, objectName: string): Promise<ReadableStream>

--- a/src/minio.js
+++ b/src/minio.js
@@ -2388,15 +2388,6 @@ export class Client extends TypedClient {
     })
   }
 
-  removeBucketReplication(bucketName, cb) {
-    if (!isValidBucketName(bucketName)) {
-      throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
-    }
-    const method = 'DELETE'
-    const query = 'replication'
-    this.makeRequest({ method, bucketName, query }, '', [200, 204], '', false, cb)
-  }
-
   getObjectLegalHold(bucketName, objectName, getOpts = {}, cb) {
     if (!isValidBucketName(bucketName)) {
       throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
@@ -2853,7 +2844,6 @@ Client.prototype.getBucketEncryption = promisify(Client.prototype.getBucketEncry
 Client.prototype.removeBucketEncryption = promisify(Client.prototype.removeBucketEncryption)
 Client.prototype.setBucketReplication = promisify(Client.prototype.setBucketReplication)
 Client.prototype.getBucketReplication = promisify(Client.prototype.getBucketReplication)
-Client.prototype.removeBucketReplication = promisify(Client.prototype.removeBucketReplication)
 Client.prototype.setObjectLegalHold = promisify(Client.prototype.setObjectLegalHold)
 Client.prototype.getObjectLegalHold = promisify(Client.prototype.getObjectLegalHold)
 Client.prototype.composeObject = promisify(Client.prototype.composeObject)
@@ -2863,3 +2853,4 @@ Client.prototype.selectObjectContent = promisify(Client.prototype.selectObjectCo
 Client.prototype.removeObject = callbackify(Client.prototype.removeObject)
 Client.prototype.removeBucket = callbackify(Client.prototype.removeBucket)
 Client.prototype.listBuckets = callbackify(Client.prototype.listBuckets)
+Client.prototype.removeBucketReplication = callbackify(Client.prototype.removeBucketReplication)

--- a/tests/unit/test.js
+++ b/tests/unit/test.js
@@ -1393,14 +1393,24 @@ describe('Client', function () {
     describe('removeBucketReplication(bucketName, callback)', () => {
       it('should fail on null bucket', (done) => {
         try {
-          client.removeBucketReplication(null, {}, function () {})
+          client.removeBucketReplication(null, function (err) {
+            if (err) {
+              return done()
+            }
+            done(new Error('callback should receive error'))
+          })
         } catch (e) {
           done()
         }
       })
       it('should fail on empty bucket', (done) => {
         try {
-          client.removeBucketReplication('', {}, function () {})
+          client.removeBucketReplication('', function (err) {
+            if (err) {
+              return done()
+            }
+            done(new Error('callback should receive error'))
+          })
         } catch (e) {
           done()
         }


### PR DESCRIPTION
 "refactor `removeBucketReplication` api to ts" 


Try to remove the bucket replication 

```js
try {
  await s3Client.removeBucketReplication('source-bucket')
  console.log('Success')
} catch (e) {
  return console.log(e)
}
```


<details>

<summary> Steps to setting up a bucket replication </summary>


```
# Setup Bucket replication e.g b/w 2 sites
Site 1 (local22)
---------
CI=true  MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server /tmp/sem{1...4}  --address ":22000" --console-address ":9025"

Site 2(local23)
---------------------------
CI=true  MINIO_ROOT_USER=minio MINIO_ROOT_PASSWORD=minio123 minio server /tmp/semc{1...4}  --address ":23000" --console-address ":9035"

mc mb local22/source-bucket
mc mb local23/dest-bucket
mc version enable local22/source-bucket
mc version enable local23/dest-bucket

mc replicate add local22/source-bucket --remote-bucket http://minio:minio123@localhost:23000/dest-bucket --priority 1 

echo "Numeric" | mc pipe local22/source-bucket
mc ls -r local22/source-bucket
mc ls -r local23/dest-bucket

mc replicate ls local22/source-bucket

```
</details>