### PR TITLE
Add option to prettier to add space between brackets

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,3 @@
+{
+  "bracketSpacing": true
+}


### PR DESCRIPTION
## Context

It's a bit painful for me to make changes to the projects due to my editor (configured to let eslint fix the issues) removing spaces between brackets, despite being the practice in this project.

## The fix

I just add a `.prettierrc` file so prettier is configured to add these spaces.