### PR TITLE
Added missing properties for BucketItem union type

### DIFF
--- a/src/internal/type.ts
+++ b/src/internal/type.ts
@@ -93,9 +93,13 @@ export type BucketItem =
       name: string
       size: number
       etag: string
+      prefix?: never
       lastModified: Date
     }
   | {
+      name?: never
+      etag?: never
+      lastModified?: never
       prefix: string
       size: 0
     }


### PR DESCRIPTION
## What does this do?

There are some missing properties in the BucketItem type Union, this PR adds them so TS can detect the correct elements returned by this type differentiating between prefix struct & name/etag struct.

## How does it look

### Before:

<img width="902" alt="Screenshot 2023-08-30 at 12 39 10" src="https://github.com/minio/minio-js/assets/33497058/f6c3b8ea-6e53-4bfb-9f41-76d4bbd87c8a">

### After:

<img width="859" alt="Screenshot 2023-08-30 at 14 57 29" src="https://github.com/minio/minio-js/assets/33497058/1c669cac-3fb4-447d-9cc8-22fc4221a57a">

