### PR TITLE
Fix truncated ListObjects request handling with non-existing NextMarker

### DIFF
--- a/src/xml-parsers.js
+++ b/src/xml-parsers.js
@@ -195,6 +195,8 @@ export function parseListObjects(xml) {
 
     if (listBucketResult.NextMarker) {
       nextMarker = listBucketResult.NextMarker
+    } else if (isTruncated && result.objects.length > 0) {
+      nextMarker = result.objects.at(-1).name;
     }
     parseCommonPrefixesEntity(listBucketResult.CommonPrefixes)
   }

--- a/src/xml-parsers.js
+++ b/src/xml-parsers.js
@@ -196,7 +196,7 @@ export function parseListObjects(xml) {
     if (listBucketResult.NextMarker) {
       nextMarker = listBucketResult.NextMarker
     } else if (isTruncated && result.objects.length > 0) {
-      nextMarker = result.objects[result.objects.length - 1].name;
+      nextMarker = result.objects[result.objects.length - 1].name
     }
     parseCommonPrefixesEntity(listBucketResult.CommonPrefixes)
   }

--- a/src/xml-parsers.js
+++ b/src/xml-parsers.js
@@ -196,7 +196,7 @@ export function parseListObjects(xml) {
     if (listBucketResult.NextMarker) {
       nextMarker = listBucketResult.NextMarker
     } else if (isTruncated && result.objects.length > 0) {
-      nextMarker = result.objects.at(-1).name;
+      nextMarker = result.objects[result.objects.length - 1].name;
     }
     parseCommonPrefixesEntity(listBucketResult.CommonPrefixes)
   }


### PR DESCRIPTION
Fix handling with Amazon S3 where the ListObjects request is truncated, but "NextMarker" is not returned, as decribed in https://docs.aws.amazon.com/AmazonS3/latest/API/API_ListObjects.html#AmazonS3-ListObjects-response-NextMarker