### PR TITLE
Update buffer-crc32 to 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "async": "^3.2.4",
         "block-stream2": "^2.1.0",
         "browser-or-node": "^2.1.1",
-        "buffer-crc32": "^0.2.13",
+        "buffer-crc32": "^1.0.0",
         "eventemitter3": "^5.0.1",
         "fast-xml-parser": "^4.2.2",
         "ipaddr.js": "^2.0.1",
@@ -3043,12 +3043,11 @@
       }
     },
     "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-1.0.0.tgz",
+      "integrity": "sha512-Db1SbgBS/fg/392AblrMJk97KggmvYhr4pB5ZIMTWtaivCPMWLkmb7m21cJvpvgK+J3nsU2CmmixNBZx4vFj/w==",
       "engines": {
-        "node": "*"
+        "node": ">=8.0.0"
       }
     },
     "node_modules/buffer-from": {

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "async": "^3.2.4",
     "block-stream2": "^2.1.0",
     "browser-or-node": "^2.1.1",
-    "buffer-crc32": "^0.2.13",
+    "buffer-crc32": "^1.0.0",
     "eventemitter3": "^5.0.1",
     "fast-xml-parser": "^4.2.2",
     "ipaddr.js": "^2.0.1",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,6 @@
     "@nodelib/fs.walk": "^1.2.8",
     "@types/async": "^3.2.20",
     "@types/block-stream2": "^2.1.2",
-    "@types/buffer-crc32": "^0.2.4",
     "@types/chai": "^4.3.11",
     "@types/chai-as-promised": "^7.1.8",
     "@types/lodash": "^4.14.194",


### PR DESCRIPTION
Hey! We've spent some effort lately to clean up the buffer-crc32 library and push the 1.0.0 release forward. Thought you may want to upgrade! Should be a drop-in replacement, as you don't support very old Node.js versions already.