### PR TITLE
fix: Deno and cloudflare workers deploy

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
 
       - run: npm ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18.x'
+          node-version: '20.x'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        node_version: [ 20.x, 18.x, 16.x, 14.x, 12.x, ]
+        node_version: [ 20.x, 18.x, 16.x ]
         os: [ ubuntu-latest, windows-latest ]
 
     env:

--- a/babel-register.js
+++ b/babel-register.js
@@ -19,7 +19,6 @@ register({
         importInterop: 'node',
       },
     ],
-    '@upleveled/remove-node-prefix', // lower version of node (<14) doesn't support require('node:fs')
   ],
   presets: [
     ['@babel/preset-typescript', { allExtensions: true }],

--- a/build.mjs
+++ b/build.mjs
@@ -21,7 +21,6 @@ function options(module) {
         importInterop: 'node',
       },
     ],
-    ['@upleveled/remove-node-prefix'],
     [
       'replace-import-extension',
       {

--- a/package-lock.json
+++ b/package-lock.json
@@ -44,7 +44,6 @@
         "@types/xml2js": "^0.4.11",
         "@typescript-eslint/eslint-plugin": "^5.59.2",
         "@typescript-eslint/parser": "^5.59.2",
-        "@upleveled/babel-plugin-remove-node-prefix": "^1.0.5",
         "babel-plugin-replace-import-extension": "^1.1.3",
         "babel-plugin-transform-replace-expressions": "^0.2.0",
         "chai": "^4.3.7",
@@ -2631,15 +2630,6 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
-      }
-    },
-    "node_modules/@upleveled/babel-plugin-remove-node-prefix": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@upleveled/babel-plugin-remove-node-prefix/-/babel-plugin-remove-node-prefix-1.0.5.tgz",
-      "integrity": "sha512-fBej/v/GHClDJ3H6vgUQOFeH+4dFUrcFJbu9mfJFratnzEBebrgYxPBXv3ssaArTt9HhvgsTVqemeswTum6b2Q==",
-      "dev": true,
-      "peerDependencies": {
-        "@babel/core": "^7.0.0-0"
       }
     },
     "node_modules/@zxing/text-encoding": {

--- a/package.json
+++ b/package.json
@@ -117,7 +117,6 @@
     "@types/xml2js": "^0.4.11",
     "@typescript-eslint/eslint-plugin": "^5.59.2",
     "@typescript-eslint/parser": "^5.59.2",
-    "@upleveled/babel-plugin-remove-node-prefix": "^1.0.5",
     "babel-plugin-replace-import-extension": "^1.1.3",
     "babel-plugin-transform-replace-expressions": "^0.2.0",
     "chai": "^4.3.7",


### PR DESCRIPTION
As I reported here: https://github.com/minio/minio-js/issues/1261
There is some issue in Deno and also in Cloudflare workers to deploy.

I used a hack with ESM to deploy, but found out the only problem was the Babel config.

The good part is it's easy to fix, since it's already stated in `package.json` that the min version to use the package is Node.js 16.

The `node:` was introduced in Node.js 16.

Since then, it also got back ported to Node.js 14 and Node.js 12, but I followed what was set in `package.json` and aligned the test to run only from 16.

I also updated the lint step to run on the latest LTS, that is optional I can remove it if required.

Link: who talks about supported version: https://2ality.com/2021/12/node-protocol-imports.html

Node.js doc: https://nodejs.org/api/esm.html#node-imports
