### PR TITLE
fix: regression when listing buckets use the configured or default region

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minio",
-  "version": "7.1.4",
+  "version": "7.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minio",
-      "version": "7.1.4",
+      "version": "7.1.5",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.4",

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1483,7 +1483,8 @@ export class TypedClient {
 
   async listBuckets(): Promise<BucketItemFromList[]> {
     const method = 'GET'
-    const httpRes = await this.makeRequestAsync({ method }, '', [200], this.region ?? '')
+    const regionConf = this.region || DEFAULT_REGION
+    const httpRes = await this.makeRequestAsync({ method }, '', [200], regionConf)
     const xmlResult = await readAsString(httpRes)
     return xmlParsers.parseListBucket(xmlResult)
   }


### PR DESCRIPTION
when listing buckets use the configured or default region

We fetch the region automatically only for buckets.  so for `listBuckets`, either a region is required or use the default.

The latest version/master `listBuckets` does nor return any result .  setting a default region would work as part of the client config. 
```js
var mc = new Minio.Client({
    endPoint: 'localhost',
    accessKey: 'minio',
    secretKey: 'minio123',
    useSSL: false,
    //partSize: 1024 * 1024 * 5,
    port: 22000,
    region:"us-east-1"
  })
```

