### PR TITLE
fix use configured region from constructor for makebucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ The complete API Reference is available here:
 - [list-objects-v2.js](https://github.com/minio/minio-js/blob/master/examples/list-objects-v2.js)
 - [list-objects-v2-with-metadata.js](https://github.com/minio/minio-js/blob/master/examples/list-objects-v2-with-metadata.js) (Extension)
 - [bucket-exists.mjs](https://github.com/minio/minio-js/blob/master/examples/bucket-exists.mjs)
-- [make-bucket.js](https://github.com/minio/minio-js/blob/master/examples/make-bucket.js)
+- [make-bucket.mjs](https://github.com/minio/minio-js/blob/master/examples/make-bucket.js)
 - [remove-bucket.mjs](https://github.com/minio/minio-js/blob/master/examples/remove-bucket.mjs)
 - [list-incomplete-uploads.js](https://github.com/minio/minio-js/blob/master/examples/list-incomplete-uploads.js)
 - [get-bucket-versioning.mjs](https://github.com/minio/minio-js/blob/master/examples/get-bucket-versioning.js)

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -155,7 +155,7 @@ mc ls play/europetrip/
 * [list-objects.js](https://github.com/minio/minio-js/blob/master/examples/list-objects.js)
 * [list-objects-v2.js](https://github.com/minio/minio-js/blob/master/examples/list-objects-v2.js)
 * [bucket-exists.mjs](https://github.com/minio/minio-js/blob/master/examples/bucket-exists.mjs)
-* [make-bucket.js](https://github.com/minio/minio-js/blob/master/examples/make-bucket.js)
+* [make-bucket.mjs](https://github.com/minio/minio-js/blob/master/examples/make-bucket.js)
 * [remove-bucket.mjs](https://github.com/minio/minio-js/blob/master/examples/remove-bucket.mjs)
 * [list-incomplete-uploads.js](https://github.com/minio/minio-js/blob/master/examples/list-incomplete-uploads.js)
 

--- a/examples/make-bucket.mjs
+++ b/examples/make-bucket.mjs
@@ -24,6 +24,11 @@ const s3Client = new Minio.Client({
   accessKey: 'YOUR-ACCESSKEYID',
   secretKey: 'YOUR-SECRETACCESSKEY',
 })
+
+// Create a bucket name my-bucketname-nr.
+await s3Client.makeBucket('my-bucketname-nr')
+console.log('Success')
+
 // Create a bucket name my-bucketname.
 await s3Client.makeBucket('my-bucketname', 'us-west-1')
 

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -892,10 +892,9 @@ export class TypedClient {
       headers['x-amz-bucket-object-lock-enabled'] = true
     }
 
-    if (!region) {
-      region = DEFAULT_REGION
-    }
-    const finalRegion = region // type narrow
+    // For custom region clients  default to custom region specified in client constructor
+    const finalRegion = this.region || region || DEFAULT_REGION
+
     const requestOpt: RequestOption = { method, bucketName, headers }
 
     try {


### PR DESCRIPTION
fix use configured region from constructor for makebucket

Fixes https://github.com/minio/minio-js/issues/1292


```
const s3Client = new Minio.Client({
  endPoint: 'localhost',
  accessKey: 'minio',
  secretKey: 'minio123',
  useSSL: false,
  port: 22000,
  // region:'us-west-1'
  //partSize: 5 * 1024 * 1024,
})

// Create a bucket name my-bucketname-3.
// await s3Client.makeBucket('my-bucketname-3')

// Create a bucket name my-bucketname.
// await s3Client.makeBucket('my-bucketname-2','us-west-1')

// List all object paths in bucket my-bucketname-2. and observe trace for the correct region in request. 
var objectsStream = s3Client.listObjects('my-bucketname-2', '', true)
objectsStream.on('data', function (obj) {
  console.log(obj)
})
objectsStream.on('error', function (e) {
  console.log(e)
})

```
to change region in MinIO,

```
 mc admin config set local22 region name=us-west-1 && mc admin service restart local22
```
to reset to default region in MinIO
```
mc admin config set local22 region name= && mc admin service restart local22
```