### PR TITLE
Ensure default expiration parameter is set for presigned URLs

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -2848,6 +2848,12 @@ export class TypedClient {
       throw new errors.AnonymousRequestError(`Presigned ${method} url cannot be generated for anonymous requests`)
     }
 
+    if (!expires) {
+      expires = PRESIGN_EXPIRY_DAYS_MAX
+    }
+    if (!reqParams) {
+      reqParams = {}
+    }
     if (!requestDate) {
       requestDate = new Date()
     }

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -2955,7 +2955,7 @@ export class TypedClient {
         // 'expiration' is mandatory field for S3.
         // Set default expiration date of 7 days.
         const expires = new Date()
-        expires.setSeconds(24 * 60 * 60 * 7)
+        expires.setSeconds(PRESIGN_EXPIRY_DAYS_MAX)
         postPolicy.setExpires(expires)
       }
 

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -43,7 +43,6 @@ import {
   isBoolean,
   isDefined,
   isEmpty,
-  isFunction,
   isNumber,
   isObject,
   isReadableStream,
@@ -2849,19 +2848,6 @@ export class TypedClient {
       throw new errors.AnonymousRequestError(`Presigned ${method} url cannot be generated for anonymous requests`)
     }
 
-    // Handle optional parameters and defaults
-    if (requestDate === undefined && isFunction(reqParams)) {
-      requestDate = new Date()
-    }
-    if (reqParams === undefined && isFunction(expires)) {
-      reqParams = {}
-      requestDate = new Date()
-    }
-    if (expires && typeof expires === 'function') {
-      expires = PRESIGN_EXPIRY_DAYS_MAX
-      reqParams = {}
-      requestDate = new Date()
-    }
     if (!requestDate) {
       requestDate = new Date()
     }
@@ -2911,18 +2897,6 @@ export class TypedClient {
     if (!isValidObjectName(objectName)) {
       throw new errors.InvalidObjectNameError(`Invalid object name: ${objectName}`)
     }
-    if (expires && isFunction(expires)) {
-      expires = PRESIGN_EXPIRY_DAYS_MAX
-      respHeaders = {}
-      requestDate = new Date()
-    }
-    if (!expires) {
-      expires = PRESIGN_EXPIRY_DAYS_MAX
-    }
-    if (isFunction(respHeaders)) {
-      respHeaders = {}
-      requestDate = new Date()
-    }
 
     const validRespHeaders = [
       'response-content-type',
@@ -2947,9 +2921,6 @@ export class TypedClient {
     }
     if (!isValidObjectName(objectName)) {
       throw new errors.InvalidObjectNameError(`Invalid object name: ${objectName}`)
-    }
-    if (expires && isFunction(expires)) {
-      expires = PRESIGN_EXPIRY_DAYS_MAX
     }
 
     return this.presignedUrl('PUT', bucketName, objectName, expires)

--- a/tests/unit/test.js
+++ b/tests/unit/test.js
@@ -381,6 +381,34 @@ describe('Client', function () {
     })
   })
   describe('Presigned URL', () => {
+    describe('presignedUrl', () => {
+      const client = new Minio.Client({
+        endPoint: 'localhost',
+        port: 9000,
+        accessKey: 'accesskey',
+        secretKey: 'secretkey',
+        useSSL: false,
+        region: 'us-east-1'
+      })
+
+      it('should use the default expiry if omitted', async () => {
+        const url = await client.presignedUrl('get', 'bucket', 'object')
+        return expect(url).to.contain('X-Amz-Expires=604800')
+      })
+      it('should set the expiry time', async () => {
+        const url = await client.presignedUrl('get', 'bucket', 'object', 3600)
+        return expect(url).to.contain('X-Amz-Expires=3600')
+      })
+      it('should reject an invalid expiry time', async() => {
+        await expect(client.presignedUrl('get', 'bucket', 'object', 'invalid')).to.eventually.be.rejectedWith("expires should be of type \"number\"")
+      })
+      it('should handle a callback function', (done) => {
+        client.presignedUrl('get', 'bucket', 'object', (error, result) => {
+          expect(result).to.contain('X-Amz-Expires=604800')
+          done()
+        })
+      })
+    })
     describe('presigned-get', () => {
       it('should not generate presigned url with no access key', async () => {
         try {

--- a/tests/unit/test.js
+++ b/tests/unit/test.js
@@ -388,7 +388,7 @@ describe('Client', function () {
         accessKey: 'accesskey',
         secretKey: 'secretkey',
         useSSL: false,
-        region: 'us-east-1'
+        region: 'us-east-1',
       })
 
       it('should use the default expiry if omitted', async () => {
@@ -399,8 +399,10 @@ describe('Client', function () {
         const url = await client.presignedUrl('get', 'bucket', 'object', 3600)
         return expect(url).to.contain('X-Amz-Expires=3600')
       })
-      it('should reject an invalid expiry time', async() => {
-        await expect(client.presignedUrl('get', 'bucket', 'object', 'invalid')).to.eventually.be.rejectedWith("expires should be of type \"number\"")
+      it('should reject an invalid expiry time', async () => {
+        await expect(client.presignedUrl('get', 'bucket', 'object', 'invalid')).to.eventually.be.rejectedWith(
+          'expires should be of type "number"',
+        )
       })
       it('should handle a callback function', (done) => {
         client.presignedUrl('get', 'bucket', 'object', (error, result) => {


### PR DESCRIPTION
Resolves #1312 

Additionally, remove unnecessary `isFunction` checks as that is now handled by the callbackify wrapper.

Added module in unit test library for better coverage.