### PR TITLE
Fix type definition entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   "exports": {
     ".": {
       "require": "./dist/main/minio.js",
-      "types": "./types/esm/minio.d.ts",
+      "types": "./dist/main/minio.d.ts",
       "default": "./dist/esm/minio.mjs"
     },
     "./dist/main/internal/*": null,


### PR DESCRIPTION
Hello, I'm currently using version 8.0.1, but I still encountered this issue [Cannot find type definition file for 'minio'](https://github.com/minio/minio-js/issues/1257) yesterday. 

The current entry point `"types": "./types/esm/minio.d.ts"` is incorrect, and the actual directory 'types' does not exist, as shown in the screenshot below. 


<img width="960" alt="image" src="https://github.com/minio/minio-js/assets/18410118/0c598448-1dff-40e0-9646-58eb7d257003">


<img width="1128" alt="image" src="https://github.com/minio/minio-js/assets/18410118/de0bf43e-64e6-4aa6-98f1-6446c6ee3422">


The correct address should be `"types": "./dist/main/minio.d.ts"`

