### PR TITLE
BUG-#1324 add custom headers to request when uploading multipart object

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1745,6 +1745,7 @@ export class TypedClient {
             headers: {
               'Content-Length': chunk.length,
               'Content-MD5': md5.toString('base64'),
+              ...headers,
             },
             bucketName,
             objectName,


### PR DESCRIPTION
Issue: https://github.com/minio/minio-js/issues/1324
Info:
Encryption headers are not passed when uploading an object that requires a multipart upload.

FYI:
Headers are already prepended using `prependXAMZMeta` in the `putObject` function, so it is no necessary to do it again but wouldn't do any harm if you want to do it again just to be sure. 