### PR TITLE
fix: uploadPart cannot upload stream and etag error

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -2656,8 +2656,6 @@ export class TypedClient {
     const query = `uploadId=${uploadID}&partNumber=${partNumber}`
     const requestOptions = { method, bucketName, objectName: objectName, query, headers }
     const res = await this.makeRequestAsync(requestOptions, payload)
-    // const body = await readAsString(res)
-    // const partRes = uploadPartParser(body)
     return {
       etag: sanitizeETag(res.headers.etag),
       key: objectName,

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -121,7 +121,6 @@ import {
   parseInitiateMultipart,
   parseObjectLegalHoldConfig,
   parseSelectObjectContentResponse,
-  uploadPartParser,
 } from './xml-parser.ts'
 
 const xml = new xml2js.Builder({ renderOpts: { pretty: false }, headless: true })
@@ -2641,25 +2640,26 @@ export class TypedClient {
     return await this.copyObjectV2(source, dest)
   }
 
-  async uploadPart(partConfig: {
-    bucketName: string
-    objectName: string
-    uploadID: string
-    partNumber: number
-    headers: RequestHeaders
-  }) {
+  async uploadPart(
+    partConfig: {
+      bucketName: string
+      objectName: string
+      uploadID: string
+      partNumber: number
+      headers: RequestHeaders
+    },
+    payload?: Binary,
+  ) {
     const { bucketName, objectName, uploadID, partNumber, headers } = partConfig
 
     const method = 'PUT'
     const query = `uploadId=${uploadID}&partNumber=${partNumber}`
     const requestOptions = { method, bucketName, objectName: objectName, query, headers }
-
-    const res = await this.makeRequestAsync(requestOptions)
-    const body = await readAsString(res)
-    const partRes = uploadPartParser(body)
-
+    const res = await this.makeRequestAsync(requestOptions, payload)
+    // const body = await readAsString(res)
+    // const partRes = uploadPartParser(body)
     return {
-      etag: sanitizeETag(partRes.ETag),
+      etag: sanitizeETag(res.headers.etag),
       key: objectName,
       part: partNumber,
     }


### PR DESCRIPTION
S3 API can upload a binary file in the body. We need this feature for users to implement slicing and uploading files themselves.
https://docs.aws.amazon.com/AmazonS3/latest/API/API_UploadPart.html
