### PR TITLE
fix: fast-xml-parser version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "browser-or-node": "^2.1.1",
         "buffer-crc32": "^1.0.0",
         "eventemitter3": "^5.0.1",
-        "fast-xml-parser": "^4.2.2",
+        "fast-xml-parser": "^4.4.1",
         "ipaddr.js": "^2.0.1",
         "lodash": "^4.17.21",
         "mime-types": "^2.1.35",
@@ -4307,6 +4307,7 @@
           "url": "https://paypal.me/naturalintelligence"
         }
       ],
+      "license": "MIT",
       "dependencies": {
         "strnum": "^1.0.5"
       },

--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "browser-or-node": "^2.1.1",
     "buffer-crc32": "^1.0.0",
     "eventemitter3": "^5.0.1",
-    "fast-xml-parser": "^4.2.2",
+    "fast-xml-parser": "^4.4.1",
     "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35",


### PR DESCRIPTION
Even though this PR was merged https://github.com/minio/minio-js/pull/1328
`npm` pulls `"fast-xml-parser": "^4.2.2"` from `package.json`
Which has `Regular Expression Denial of Service (ReDoS)` https://security.snyk.io/package/npm/fast-xml-parser

<img width="426" alt="Screenshot 2024-08-14 at 15 17 19" src="https://github.com/user-attachments/assets/f93e219a-645d-4553-92c9-75d9b89700eb">

