### PR TITLE
fix: add missing file extension to import

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -25,7 +25,7 @@ import {
   RETENTION_MODES,
   RETENTION_VALIDITY_UNITS,
 } from '../helpers.ts'
-import type { PostPolicyResult } from '../minio'
+import type { PostPolicyResult } from '../minio.ts'
 import { postPresignSignatureV4, presignSignatureV4, signV4 } from '../signing.ts'
 import { fsp, streamPromise } from './async.ts'
 import { CopyConditions } from './copy-conditions.ts'


### PR DESCRIPTION
The type import of `PostPolicyResult` in `src/internal/client.ts` is missing its file extension. 

This can cause issues with projects requiring file extensions on import paths:

```
node_modules/minio/dist/esm/internal/client.d.mts:11:39 - error TS2307: Cannot find module '../minio' or its corresponding type declarations.

11 import type { PostPolicyResult } from '../minio';
                                         ~~~~~~~~~~


Found 1 error in node_modules/minio/dist/esm/internal/client.d.mts:11
``` 

I've added a `.ts` file extension similar to the import of `xml-parser.ts`, which also only exists as `.js`-file