### PR TITLE
Rethrow exceptions other than InvalidBucketNameError

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -2886,7 +2886,11 @@ export class TypedClient {
         expires,
       )
     } catch (err) {
-      throw new errors.InvalidArgumentError(`Unable to get bucket region for  ${bucketName}.`)
+      if (err instanceof errors.InvalidBucketNameError) {
+        throw new errors.InvalidArgumentError(`Unable to get bucket region for ${bucketName}.`)
+      }
+
+      throw err
     }
   }
 
@@ -2987,8 +2991,12 @@ export class TypedClient {
       const portStr = this.port == 80 || this.port === 443 ? '' : `:${this.port.toString()}`
       const urlStr = `${reqOptions.protocol}//${reqOptions.host}${portStr}${reqOptions.path}`
       return { postURL: urlStr, formData: postPolicy.formData }
-    } catch (er) {
-      throw new errors.InvalidArgumentError(`Unable to get bucket region for  ${bucketName}.`)
+    } catch (err) {
+      if (err instanceof errors.InvalidBucketNameError) {
+        throw new errors.InvalidArgumentError(`Unable to get bucket region for ${bucketName}.`)
+      }
+
+      throw err
     }
   }
 }


### PR DESCRIPTION
I had an issue where this minio client throws a `InvalidArgumentError: Unable to get bucket region for ...` error when trying to retrieve a presigned url. I was so confused as to why would I need to configure bucket regions for minio because I'm running it locally on as a docker container.

I modified the source to `console.error` the error and it appears like the original error was actually an `ECONNREFUSED`, masked behind the incorrect `InvalidArgumentError` because of the large try-catch statement.

In this PR, I made it so that it would only throw `InvalidArgumentError` only when the originating error is an `InvalidBucketNameError`, and rethrow any other error.