### PR TITLE
feat: port support string type

### DIFF
--- a/src/internal/helper.ts
+++ b/src/internal/helper.ts
@@ -141,13 +141,16 @@ export function probeContentType(path: string) {
  * is input port valid.
  */
 export function isValidPort(port: unknown): port is number {
-  // verify if port is a number.
-  if (!isNumber(port)) {
+  // Convert string port to number if needed
+  const portNum = typeof port === 'string' ? parseInt(port, 10) : port
+
+  // verify if port is a valid number
+  if (!isNumber(portNum) || isNaN(portNum)) {
     return false
   }
 
   // port `0` is valid and special case
-  return 0 <= port && port <= 65535
+  return 0 <= portNum && portNum <= 65535
 }
 
 export function isValidBucketName(bucket: unknown) {


### PR DESCRIPTION
I want the port to support string type for two reasons:

1. Many well-known libraries support both string and number for port configuration, since ports are typically loaded from env files where values are strings. This way, users don't need to perform type conversion.

2. Many people, including myself, find that when the port is passed as a string type, the error message is not very clear, only showing "invalid port".