### PR TITLE
feat: new option customEndpointHost

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -67,19 +67,20 @@ const s3Client = new Minio.Client({
 
 **Parameters**
 
-| Param            | Type                                                      | Description                                                                                                                        |
-| ---------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------- |
-| `endPoint`       | _string_                                                  | endPoint is a host name or an IP address.                                                                                          |
-| `port`           | _number_                                                  | TCP/IP port number. This input is optional. Default value set to 80 for HTTP and 443 for HTTPs.                                    |
-| `useSSL`         | _bool_                                                    | If set to true, https is used instead of http. Default is true.                                                                    |
-| `accessKey`      | _string_                                                  | accessKey is like user-id that uniquely identifies your account.                                                                   |
-| `secretKey`      | _string_                                                  | secretKey is the password to your account.                                                                                         |
-| `sessionToken`   | _string_                                                  | Set this value to provide x-amz-security-token (AWS S3 specific). (Optional)                                                       |
-| `region`         | _string_                                                  | Set this value to override region cache. (Optional)                                                                                |
-| `transport`      | _string_                                                  | Set this value to pass in a custom transport. (Optional)                                                                           |
-| `partSize`       | _number_                                                  | Set this value to override default part size of 64MB for multipart uploads. (Optional)                                             |
-| `pathStyle`      | _bool_                                                    | Set this value to override default access behavior (path) for non AWS endpoints. Default is true. (Optional)                       |
-| `transportAgent` | [Agent](https://nodejs.org/api/http.html#class-httpagent) | Set this value to provide a custom HTTP(s) agent to handle timeouts, TLS handling, and low-level socket configurations. (Optional) |
+| Param                | Type                                                      | Description                                                                                                                                                |
+| -------------------- | --------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `endPoint`           | _string_                                                  | endPoint is a host name or an IP address.                                                                                                                  |
+| `port`               | _number_                                                  | TCP/IP port number. This input is optional. Default value set to 80 for HTTP and 443 for HTTPs.                                                            |
+| `useSSL`             | _bool_                                                    | If set to true, https is used instead of http. Default is true.                                                                                            |
+| `accessKey`          | _string_                                                  | accessKey is like user-id that uniquely identifies your account.                                                                                           |
+| `secretKey`          | _string_                                                  | secretKey is the password to your account.                                                                                                                 |
+| `sessionToken`       | _string_                                                  | Set this value to provide x-amz-security-token (AWS S3 specific). (Optional)                                                                               |
+| `region`             | _string_                                                  | Set this value to override region cache. (Optional)                                                                                                        |
+| `transport`          | _string_                                                  | Set this value to pass in a custom transport. (Optional)                                                                                                   |
+| `partSize`           | _number_                                                  | Set this value to override default part size of 64MB for multipart uploads. (Optional)                                                                     |
+| `pathStyle`          | _bool_                                                    | Set this value to override default access behavior (path) for non AWS endpoints. Default is true. (Optional)                                               |
+| `transportAgent`     | [Agent](https://nodejs.org/api/http.html#class-httpagent) | Set this value to provide a custom HTTP(s) agent to handle timeouts, TLS handling, and low-level socket configurations. (Optional)                         |
+| `customEndpointHost` | _bool_                                                    | Consider endPoint as a custom domain name that ultimately reaches the S3 service for the request, without any additional domain name processing.(Optional) |
 
 **Example**
 

--- a/docs/zh_CN/API.md
+++ b/docs/zh_CN/API.md
@@ -66,6 +66,8 @@ __参数__
 |`sessionToken`    | _string_  |Set this value to provide x-amz-security-token (AWS S3 specific). (Optional) - To be translated|
 |`partSize`    | _number_  |Set this value to override default part size of 64MB for multipart uploads. (Optional) - To be translated|
 | `pathStyle`    | _bool_   | 对于非 AWS 的 Endpoint，设置该值以覆盖默认访问方式 (path)。默认值为 true。（可选） |
+| `transportAgent` | [Agent](https://nodejs.org/api/http.html#class-httpagent) | 设置此值以提供自定义HTTP代理来处理超时、TLS处理和低级套接字配置。(Optional) |
+| `customEndpointHost`    | _bool_   | 将endPoint视作请求最终到达s3服务的自定义域名，不会额外处理域名。默认值为 false。（可选） |
 
 __示例__
 

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -163,6 +163,7 @@ export interface ClientOptions {
   credentialsProvider?: CredentialProvider
   s3AccelerateEndpoint?: string
   transportAgent?: http.Agent
+  customEndpointHost?: boolean
 }
 
 export type RequestOption = Partial<IRequest> & {
@@ -212,6 +213,7 @@ export class TypedClient {
   public enableSHA256: boolean
   protected s3AccelerateEndpoint?: string
   protected reqOptions: Record<string, unknown>
+  protected customEndpointHost = false
 
   protected transportAgent: http.Agent
   private readonly clientExtensions: Extensions
@@ -246,6 +248,9 @@ export class TypedClient {
       if (!isString(params.region)) {
         throw new errors.InvalidArgumentError(`Invalid region : ${params.region}`)
       }
+    }
+    if (params.customEndpointHost) {
+      this.customEndpointHost = true
     }
 
     const host = params.endPoint.toLowerCase()
@@ -470,7 +475,8 @@ export class TypedClient {
       //
       //  var host = 'bucketName.example.com'
       //
-      if (bucketName) {
+      // Sometime, we need to support custom endpoint host, so we need to check if customEndpointHost is set.
+      if (bucketName && !this.customEndpointHost) {
         host = `${bucketName}.${host}`
       }
       if (objectName) {


### PR DESCRIPTION
Some cloud storage providers support custom domain names, but the existing configuration automatically appends the bucket name, causing service access issues.

For instance, the intended access should be to `oss.example.com`, but it instead becomes `bucket.oss.example.com`, resulting in the service being unreachable.

To address this situation, this Pull Request (PR) introduces the `customEndpointHost` configuration. When enabled, it uses the endpoint as the final request hostname without processing additional strings, allowing the aforementioned example to function correctly.