### PR TITLE
Support if-none-match and if-match headers.

### DIFF
--- a/src/internal/helper.ts
+++ b/src/internal/helper.ts
@@ -376,6 +376,8 @@ export function isSupportedHeader(key: string) {
     'content-disposition',
     'content-language',
     'x-amz-website-redirect-location',
+    'if-none-match',
+    'if-match',
   ]
   return supported_headers.includes(key.toLowerCase())
 }


### PR DESCRIPTION
S3 and the Minio server both support [conditional writes](https://blog.min.io/leading-the-way-minios-conditional-write-feature-for-modern-data-workloads/) using `If-None-Match` and `If-Match`. Fwiw, this is [already supported](https://github.com/minio/minio-go/blob/ffa2ddd6f2b41e522235a3c61fb4ff5910a842d7/api-put-object.go#L132) in the Go client.

Previously this was treating those parameters as metadata, but now they're treated as proper headers.

Example:
```
minioClient.putObject(
  "my-bucket",
  "my-object",
  "object-content",
  undefined,
  {
    "If-None-Match": "*",
  }
);
```