### PR TITLE
CI: add Node 22 to version matrix

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - run: npm ci
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
         with:
-          node-version: '20.x'
+          node-version: '22.x'
           cache: 'npm'
 
       - run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 5
       matrix:
-        node_version: [ 20.x, 18.x, 16.x ]
+        node_version: [22.x, 20.x, 18.x, 16.x ]
         os: [ ubuntu-latest, windows-latest ]
 
     env:


### PR DESCRIPTION
Add Node.js 22 to CI version matrix. It is the current LTS version of Node, so makes sense to ensure the JS client works with that too.

For successful test run, see the PR in this [fork](https://github.com/stscoundrel/minio-js/pull/1)