### PR TITLE
Fix: make putOpts optional in setObjectTagging

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -2253,7 +2253,7 @@ export class TypedClient {
     await this.removeTagging({ bucketName })
   }
 
-  async setObjectTagging(bucketName: string, objectName: string, tags: Tags, putOpts: TaggingOpts) {
+  async setObjectTagging(bucketName: string, objectName: string, tags: Tags, putOpts?: TaggingOpts) {
     if (!isValidBucketName(bucketName)) {
       throw new errors.InvalidBucketNameError('Invalid bucket name: ' + bucketName)
     }


### PR DESCRIPTION
Hello all,

previously, putOpts was required, causing issues when not provided.
This fix makes it optional as intended.

Also the `examples/set-object-tagging.mjs` is now working as intended.

Resolves #1247