### PR TITLE
fix 0 byte file upload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "minio",
-  "version": "8.0.4",
+  "version": "8.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "minio",
-      "version": "8.0.4",
+      "version": "8.0.5",
       "license": "Apache-2.0",
       "dependencies": {
         "async": "^3.2.4",

--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1658,7 +1658,7 @@ export class TypedClient {
     }
 
     const partSize = this.calculatePartSize(size)
-    if (typeof stream === 'string' || Buffer.isBuffer(stream) || size <= partSize) {
+    if (typeof stream === 'string' || stream.readableLength === 0 || Buffer.isBuffer(stream) || size <= partSize) {
       const buf = isReadableStream(stream) ? await readAsBuffer(stream) : Buffer.from(stream)
       return this.uploadBuffer(bucketName, objectName, headers, buf)
     }


### PR DESCRIPTION
fix 0 byte file upload

Fixes https://github.com/minio/minio-js/issues/1386
Test Script:
<details>

```js
import * as Minio from 'minio'
import * as fs from 'fs'
import * as stream from 'stream'

var minioClient = new Minio.Client({
  endPoint: 'localhost',
  port: 22000,
  useSSL: false,
  accessKey: 'minio',
  secretKey: 'minio123',
  //pathStyle:true
})

const testUserBug = async () => {
  const destinationObject = 'empty-file'

  var metaData = {
    'Content-Type': 'text/plain',
    'X-Amz-Meta-Testing': 1234,
    example: 5678,
  }

  const filePath = '/dev/null'
  const stream = fs.createReadStream(filePath, { highWaterMark: 1024 * 1024 })
  //const { size } = await fs.promises.stat(filePath)

  // const result = await minioClient.putObject('test-bucket', destinationObject, stream, metaData)
  //console.log(result)

  let size = 0
  // Get a full object.
  const dataStream1 = await minioClient.getObject('test-bucket', destinationObject)

  dataStream1.on('data', function (chunk) {
    size += chunk.length
  })
  dataStream1.on('end', function () {
    console.log('End. Total size = ' + size)
  })
  dataStream1.on('error', function (e) {
    console.log(e)
  })
}
testUserBug()
```
</details>