### PR TITLE
Allow to presign url with custom origin

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -95,6 +95,7 @@ import type {
   ObjectLockInfo,
   ObjectMetaData,
   ObjectRetentionInfo,
+  PreSignOriginParams,
   PreSignRequestParams,
   PutObjectLegalHoldOptions,
   PutTaggingParams,
@@ -2862,6 +2863,7 @@ export class TypedClient {
     expires?: number | PreSignRequestParams | undefined,
     reqParams?: PreSignRequestParams | Date,
     requestDate?: Date,
+    origin?: PreSignOriginParams,
   ): Promise<string> {
     if (this.anonymous) {
       throw new errors.AnonymousRequestError(`Presigned ${method} url cannot be generated for anonymous requests`)
@@ -2894,6 +2896,15 @@ export class TypedClient {
       const region = await this.getBucketRegionAsync(bucketName)
       await this.checkAndRefreshCreds()
       const reqOptions = this.getRequestOptions({ method, region, bucketName, objectName, query })
+
+      if (origin?.protocol) {
+        reqOptions.protocol = origin.protocol
+      }
+
+      if (origin?.host) {
+        reqOptions.host = origin.host
+        reqOptions.headers.host = origin.host
+      }
 
       return presignSignatureV4(
         reqOptions,

--- a/src/internal/type.ts
+++ b/src/internal/type.ts
@@ -466,6 +466,11 @@ export type UploadPartConfig = {
 
 export type PreSignRequestParams = { [key: string]: string }
 
+export type PreSignOriginParams = {
+  protocol: string
+  host: string
+}
+
 /** List object api types **/
 
 // Common types


### PR DESCRIPTION
In many Docker-based deployments, MinIO runs in a private network alongside backend services, while being exposed to end users through a reverse proxy. However, MinIO’s SDKs (such as minio-js) generate presigned URLs based on the internal endpoint and port, which are not accessible externally.

This PR introduces the ability to modify the presigned URL's origin before signing. This allows developers to specify an externally reachable URL (e.g., a reverse proxy) instead of the internal MinIO service address.

In my setup, MinIO runs as a container (minio:9000), and my backend (which uses minio-js) is in the same private network. Users, however, access MinIO via an Nginx reverse proxy (https://minio.example.app). Without this change, presigned URLs point to minio:9000, which is unreachable for end users. By allowing origin modification, the backend can generate URLs that correctly route through the reverse proxy, ensuring accessibility.