### PR TITLE
fix large object upload and and update functional test for 0 byte file upload

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1596,7 +1596,7 @@ export class TypedClient {
 
     // Inserts correct `content-type` attribute based on metaData and filePath
     metaData = insertContentType(metaData || {}, filePath)
-    const stat = await fsp.lstat(filePath)
+    const stat = await fsp.stat(filePath)
     return await this.putObject(bucketName, objectName, fs.createReadStream(filePath), stat.size, metaData)
   }
 
@@ -1656,9 +1656,12 @@ export class TypedClient {
       // Backward compatibility
       size = this.maxObjectSize
     }
+    if (size === 0) {
+      return this.uploadBuffer(bucketName, objectName, headers, Buffer.from(''))
+    }
 
     const partSize = this.calculatePartSize(size)
-    if (typeof stream === 'string' || stream.readableLength === 0 || Buffer.isBuffer(stream) || size <= partSize) {
+    if (typeof stream === 'string' || Buffer.isBuffer(stream) || size <= partSize) {
       const buf = isReadableStream(stream) ? await readAsBuffer(stream) : Buffer.from(stream)
       return this.uploadBuffer(bucketName, objectName, headers, buf)
     }

--- a/tests/functional/functional-tests.js
+++ b/tests/functional/functional-tests.js
@@ -325,6 +325,23 @@ describe('functional tests', function () {
           .catch(done)
       },
     )
+
+    step(
+      `putObject(bucketName, objectName, 0byte)_bucketName:${bucketName}, objectName:${_MultiPath100kbObjectBufferName}, 0bytefile`,
+      (done) => {
+        client
+          .putObject(bucketName, '0bytefile', '')
+          .then(() => done())
+          .catch(done)
+      },
+    )
+
+    step(`removeObject(0byte, objectName)_bucketName:${bucketName}, objectName:0bytefile`, (done) => {
+      client
+        .removeObject(bucketName, '0bytefile')
+        .then(() => done())
+        .catch(done)
+    })
   })
   describe('tests for putObject copyObject getObject getPartialObject statObject removeObject', function () {
     var tmpFileUpload = `${tmpDir}/${_100kbObjectName}`


### PR DESCRIPTION
- update `fPutObject` to use `stat` instead of `lstat`
- update functional test to include 0byte file
- fix upload of files larger than 1GB as `stream.readableLength` is not compatible
- 
Fixes https://github.com/minio/minio-js/issues/1395