### PR TITLE
Fix: redirect xml parser error to stream error, else error is uncatchable 

### DIFF
--- a/src/transformers.js
+++ b/src/transformers.js
@@ -52,7 +52,12 @@ export function getConcater(parser, emitError) {
       }
       if (bufs.length) {
         if (parser) {
-          this.push(parser(Buffer.concat(bufs).toString()))
+          try {
+            this.push(parser(Buffer.concat(bufs).toString()))
+          } catch (e) {
+            cb(e)
+            return
+          }
         } else {
           this.push(Buffer.concat(bufs))
         }


### PR DESCRIPTION
currently parser error like:
https://github.com/minio/minio-js/blob/8.0.5/src/xml-parsers.js#L101 will be un-catchable from app code

to reproduce similar situation, change local code in `parseListObjectsV2` in `node_modules/minio/dist/main/xml-parsers.js` to:
```diff
-- if (!xmlobj.ListBucketResult) {
    throw new errors.InvalidXMLError('Missing tag: "ListBucketResult"');
-- }
```
and try catch this error from `mc.listObjectsV2()`