### PR TITLE
feat: export IamAwsProvider from main minio module

### DIFF
--- a/src/minio.d.ts
+++ b/src/minio.d.ts
@@ -53,6 +53,7 @@ export type { Region } from './internal/s3-endpoints.ts'
 export type * from './notification.ts'
 export * from './notification.ts'
 export { CopyConditions, PostPolicy }
+export { IamAwsProvider } from './IamAwsProvider.ts'
 export type { MakeBucketOpt } from './internal/client.ts'
 export type {
   BucketItem,

--- a/src/minio.js
+++ b/src/minio.js
@@ -42,6 +42,7 @@ export * from './errors.ts'
 export * from './helpers.ts'
 export * from './notification.ts'
 export { CopyConditions, PostPolicy }
+export { IamAwsProvider } from './IamAwsProvider.ts'
 
 export class Client extends TypedClient {
   //


### PR DESCRIPTION
Enable direct import of IamAwsProvider class instead of requiring
internal path imports. Users can now use:
```
import { IamAwsProvider } from 'minio'
```

Instead of
```
import {IamAwsProvider} from 'minio/dist/main/IamAwsProvider.js';
```