### PR TITLE
feat: explicitly define logger

### DIFF
--- a/src/internal/logger.ts
+++ b/src/internal/logger.ts
@@ -1,0 +1,8 @@
+/**
+ * Logger provides a common interface for logging.
+ * This interface is compatible with the default `console` logger.
+ */
+export interface Logger {
+    warn(message: string, ...optionalParams: never[]): void;
+    log(message: string, ...optionalParams: never[]): void;
+}

--- a/src/internal/request.ts
+++ b/src/internal/request.ts
@@ -5,6 +5,7 @@ import { pipeline } from 'node:stream'
 import { promisify } from 'node:util'
 
 import type { Transport } from './type.ts'
+import { Logger } from './logger.ts'
 
 const pipelineAsync = promisify(pipeline)
 
@@ -63,6 +64,7 @@ export async function requestWithRetry(
   opt: https.RequestOptions,
   body: Buffer | string | stream.Readable | null = null,
   maxRetries: number = MAX_RETRIES,
+  logger: Logger,
 ): Promise<http.IncomingMessage> {
   let attempt = 0
   let isRetryable = false
@@ -85,8 +87,7 @@ export async function requestWithRetry(
           throw new Error(`Request failed after ${maxRetries} retries: ${err}`)
         }
         const delay = getExpBackOffDelay(attempt)
-        // eslint-disable-next-line no-console
-        console.warn(
+        logger.warn(
           `${new Date().toLocaleString()} Retrying request (attempt ${attempt}/${maxRetries}) after ${delay}ms due to: ${err}`,
         )
         await sleep(delay)

--- a/src/internal/xml-parser.ts
+++ b/src/internal/xml-parser.ts
@@ -22,6 +22,7 @@ import type {
   Tags,
 } from './type.ts'
 import { RETENTION_VALIDITY_UNITS } from './type.ts'
+import { Logger } from './logger.ts'
 
 // parse XML response for bucket region
 export function parseBucketRegion(xml: string): string {
@@ -459,7 +460,7 @@ function extractHeaderValue(stream: stream.Readable) {
   return Buffer.from(stream.read(bodyLen)).toString()
 }
 
-export function parseSelectObjectContentResponse(res: Buffer) {
+export function parseSelectObjectContentResponse(res: Buffer, logger: Logger) {
   const selectResults = new SelectResults({}) // will be returned
 
   const responseStream = readableStream(res) // convert byte array to a readable responseStream
@@ -577,9 +578,9 @@ export function parseSelectObjectContentResponse(res: Buffer) {
           default: {
             // Continuation message: Not sure if it is supported. did not find a reference or any message in response.
             // It does not have a payload.
-            const warningMessage = `Un implemented event detected  ${messageType}.`
+            const warningMessage = `Unimplemented event detected  ${messageType}.`
             // eslint-disable-next-line no-console
-            console.warn(warningMessage)
+            logger.warn(warningMessage)
           }
         }
       }


### PR DESCRIPTION
Dear future minio-js maintainers: DO NOT USE CONSOLE AT ALL. It's painful to debug why a certain log suddenly pop up without a sensible message explaining (1) where the log came from, and (2) what caused this log to show up.

With exposing the logger as an interface to the users, they can create a prefix or identifier that this log is coming from the MinIO JS SDK.

This will definitely conflict with https://github.com/minio/minio-js/pull/1426, so please merge https://github.com/minio/minio-js/pull/1426 first.