### PR TITLE
Update fast-xml-parser version to 5.5.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -88,7 +88,7 @@
     "browser-or-node": "^2.1.1",
     "buffer-crc32": "^1.0.0",
     "eventemitter3": "^5.0.1",
-    "fast-xml-parser": "^5.3.4",
+    "fast-xml-parser": "^5.5.7",
     "ipaddr.js": "^2.0.1",
     "lodash": "^4.17.21",
     "mime-types": "^2.1.35",


### PR DESCRIPTION
fixes 2 security issues:
https://access.redhat.com/security/cve/cve-2026-33036

https://github.com/NaturalIntelligence/fast-xml-parser/security/advisories/GHSA-8gc5-j5rx-235r