### PR TITLE
fix: return lifecycle Rule as an array for a single rule (#1407)

### DIFF
--- a/src/internal/xml-parser.ts
+++ b/src/internal/xml-parser.ts
@@ -697,7 +697,13 @@ export function parseSelectObjectContentResponse(res: Buffer) {
 
 export function parseLifecycleConfig(xml: string) {
   const xmlObj = parseXml(xml)
-  return xmlObj.LifecycleConfiguration
+  const lifecycleConfig = xmlObj.LifecycleConfiguration
+  if (lifecycleConfig && lifecycleConfig.Rule) {
+    // A single <Rule> is parsed as an object; normalize to an array so the
+    // result matches the LifecycleConfig type and the multiple-rules case. See #1407.
+    lifecycleConfig.Rule = toArray(lifecycleConfig.Rule)
+  }
+  return lifecycleConfig
 }
 
 export function parseBucketEncryptionConfig(xml: string) {

--- a/tests/functional/functional-tests.js
+++ b/tests/functional/functional-tests.js
@@ -2788,13 +2788,25 @@ describe('functional tests', function () {
         })
       })
 
-      step('Set lifecycle config of a bucket', (done) => {
-        client.getBucketLifecycle(bucketName, (err) => {
+      step('Get lifecycle config of a bucket', (done) => {
+        client.getBucketLifecycle(bucketName, (err, lifecycleConfig) => {
           if (err && err.code === 'NotImplemented') {
             return done()
           }
           if (err) {
             return done(err)
+          }
+          // Regression for #1407: a single <Rule> in the response must be
+          // returned as an array, matching the multiple-rules case and the
+          // LifecycleConfig type.
+          if (!lifecycleConfig || !Array.isArray(lifecycleConfig.Rule)) {
+            return done(new Error('Expected Rule to be an array for a single-rule lifecycle config'))
+          }
+          if (lifecycleConfig.Rule.length !== 1) {
+            return done(new Error(`Expected exactly one rule, got ${lifecycleConfig.Rule.length}`))
+          }
+          if (lifecycleConfig.Rule[0].ID !== 'Transition and Expiration Rule') {
+            return done(new Error(`Unexpected rule ID: ${lifecycleConfig.Rule[0].ID}`))
           }
           done()
         })

--- a/tests/unit/test.js
+++ b/tests/unit/test.js
@@ -32,7 +32,7 @@ import {
   partsRequired,
 } from '../../src/internal/helper.ts'
 import { joinHostPort } from '../../src/internal/join-host-port.ts'
-import { parseListMultipart, parseListObjects } from '../../src/internal/xml-parser.ts'
+import { parseLifecycleConfig, parseListMultipart, parseListObjects } from '../../src/internal/xml-parser.ts'
 import * as Minio from '../../src/minio.ts'
 
 const Package = { version: 'development' }
@@ -2243,6 +2243,34 @@ describe('IP Address Validations', () => {
 })
 
 describe('xml-parser', () => {
+  describe('#getBucketLifecycle()', () => {
+    // See https://github.com/minio/minio-js/issues/1407
+    const ruleXml = (id) => `
+      <Rule>
+        <ID>${id}</ID>
+        <Status>Enabled</Status>
+        <Expiration><Days>30</Days></Expiration>
+      </Rule>`
+
+    it('should return Rule as an array for a single rule', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <LifecycleConfiguration>${ruleXml('r1')}</LifecycleConfiguration>`
+      const config = parseLifecycleConfig(xml)
+      assert(Array.isArray(config.Rule), 'Rule should be an array')
+      assert.equal(config.Rule.length, 1)
+      assert.equal(config.Rule[0].ID, 'r1')
+    })
+
+    it('should return Rule as an array for multiple rules', () => {
+      const xml = `<?xml version="1.0" encoding="UTF-8"?>
+        <LifecycleConfiguration>${ruleXml('r1')}${ruleXml('r2')}</LifecycleConfiguration>`
+      const config = parseLifecycleConfig(xml)
+      assert(Array.isArray(config.Rule), 'Rule should be an array')
+      assert.equal(config.Rule.length, 2)
+      assert.equal(config.Rule[1].ID, 'r2')
+    })
+  })
+
   describe('#listObjects()', () => {
     describe('value type casting', () => {
       const xml = `


### PR DESCRIPTION
Fixes #1407

`getBucketLifecycle()` returns `Rule` as a plain object when a bucket has a single lifecycle rule, but as an array when it has several. Callers then have to handle both shapes.

The cause is in `parseLifecycleConfig` (`src/internal/xml-parser.ts`): it returns the `fast-xml-parser` output as-is, and the parser maps a single `<Rule>` element to an object instead of a one-element array. This also disagrees with the declared return type `LifecycleConfig` (`Rule: LifecycleRule[]`).

This normalizes `Rule` to an array via the existing `toArray` helper (the same pattern already used throughout this file), so `getBucketLifecycle()` always returns `Rule` as an array.

Added unit tests in `tests/unit/test.js` for the single-rule and multi-rule cases; the single-rule test fails without the change and passes with it. `npm run lint` and `tsc` are clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved bucket lifecycle XML parsing so lifecycle rules are always returned in a consistent array format, including when only a single rule is present.

* **Tests**
  * Extended unit tests to validate lifecycle parsing for both single-rule and multi-rule XML, including rule count and expected rule IDs.
  * Updated functional lifecycle API checks to explicitly retrieve and verify lifecycle configuration response shape for single-rule scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->