### PR TITLE
fix: use logStream for logging retries

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -770,6 +770,9 @@ export class TypedClient {
       reqOptions.headers.authorization = signV4(reqOptions, this.accessKey, this.secretKey, region, date, sha256sum)
     }
 
+    const logStream = this.logStream
+    const log = logStream ? (msg: string) => logStream.write(`${msg}\n`) : () => {}
+
     const response = await requestWithRetry(
       this.transport,
       reqOptions,
@@ -777,6 +780,7 @@ export class TypedClient {
       this.retryOptions.disableRetry === true ? 0 : this.retryOptions.maximumRetryCount,
       this.retryOptions.baseDelayMs,
       this.retryOptions.maximumDelayMs,
+      log,
     )
     if (!response.statusCode) {
       throw new Error("BUG: response doesn't have a statusCode")

--- a/src/internal/request.ts
+++ b/src/internal/request.ts
@@ -65,6 +65,7 @@ export async function requestWithRetry(
   maxRetries: number = MAX_RETRIES,
   baseDelayMs: number = BASE_DELAY_MS,
   maximumDelayMs: number = MAX_DELAY_MS,
+  log: (msg: string) => void = () => {},
 ): Promise<http.IncomingMessage> {
   let attempt = 0
   let isRetryable = false
@@ -87,10 +88,7 @@ export async function requestWithRetry(
           throw new Error(`Request failed after ${maxRetries} retries: ${err}`)
         }
         const delay = getExpBackOffDelay(attempt, baseDelayMs, maximumDelayMs)
-        // eslint-disable-next-line no-console
-        console.warn(
-          `${new Date().toLocaleString()} Retrying request (attempt ${attempt}/${maxRetries}) after ${delay}ms due to: ${err}`,
-        )
+        log(`Retrying request (attempt ${attempt}/${maxRetries}) after ${delay}ms due to: ${err}`)
         await sleep(delay)
       } else {
         throw err // re-throw if any request, syntax errors


### PR DESCRIPTION
I Discovered that the retry handler uses a hardcoded reference to `console.warn` for logging each retry. This is problematic because it doesn't respect the existing `Client.traceOff` function.

This patch makes it possible for `requestWithRetry` to use the existing logStream functionality, and thereby respect the user's choice of `traceOn/traceOff`.

It does technically introduce two breaking changes:

* Removes the `new Date().toLocaleString()` log prefix. This can be re-added if necessary, but since it's not done anywhere else, and the log message contains the retry stats already, it seems like noise.
* Switched from stderr (which is where console.warn writes to), to stdout. I think this is still desirable since the logging behaviour is now more consistent.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request retry logging so retry attempts are now recorded consistently with the app’s existing logging, making network behavior easier to trace and diagnose.
  * Kept retry behavior, timing, and error handling unchanged while making logs more reliable and less noisy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->