### PR TITLE
fix: number multipart parts starting at 1 in uploadStream

### DIFF
--- a/src/internal/client.ts
+++ b/src/internal/client.ts
@@ -1814,8 +1814,6 @@ export class TypedClient {
             }
           }
 
-          partNumber++
-
           // now start to upload missing part
           const options: RequestOption = {
             method: 'PUT',
@@ -1838,6 +1836,8 @@ export class TypedClient {
           }
 
           eTags.push({ part: partNumber, etag })
+
+          partNumber++
         }
 
         return await this.completeMultipartUpload(bucketName, objectName, uploadId, eTags)

--- a/tests/unit/upload-stream-partnumber-test.js
+++ b/tests/unit/upload-stream-partnumber-test.js
@@ -1,0 +1,102 @@
+/*
+ * MinIO Javascript Library for Amazon S3 Compatible Cloud Storage, (C) 2015 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import * as Crypto from 'node:crypto'
+import * as Stream from 'node:stream'
+
+import { assert } from 'chai'
+
+import * as Minio from '../../src/minio.ts'
+
+// Regression tests for #1482: uploadStream must assign multipart part numbers
+// consistently between the resume-skip branch and the upload branch. It used to
+// increment partNumber *before* uploading, so a fresh upload started at part 2
+// and a resumed upload numbered re-uploaded chunks off-by-one relative to the
+// parts it skipped, corrupting the completed multipart upload.
+describe('uploadStream multipart part numbering (#1482)', () => {
+  const partSize = 64
+
+  // A byte-mode stream that emits `count` chunks of `partSize` bytes, one per
+  // event-loop tick, so BlockStream2 yields them individually to uploadStream.
+  function bodyStream(count) {
+    const readable = new Stream.Readable({ read() {} })
+    ;(async () => {
+      for (let i = 0; i < count; i++) {
+        readable.push(Buffer.alloc(partSize, 'x'))
+        await new Promise(setImmediate)
+      }
+      readable.push(null)
+    })()
+    return readable
+  }
+
+  function makeClient() {
+    return new Minio.Client({
+      endPoint: 'localhost',
+      port: 9000,
+      useSSL: false,
+      accessKey: 'accesskey',
+      secretKey: 'secretkey',
+    })
+  }
+
+  // Stub the network-touching internals so we can observe the part numbers
+  // uploadStream assigns without talking to a server.
+  function instrument(client, oldParts = []) {
+    const record = { sentPartNumbers: [], completedParts: null }
+    client.findUploadId = async () => (oldParts.length ? 'existing-upload-id' : undefined)
+    client.initiateNewMultipartUpload = async () => 'new-upload-id'
+    client.listParts = async () => oldParts
+    client.makeRequestAsyncOmit = async (options) => {
+      const partNumber = Number(new URLSearchParams(options.query).get('partNumber'))
+      record.sentPartNumbers.push(partNumber)
+      return { headers: { etag: `"etag-${partNumber}"` } }
+    }
+    client.completeMultipartUpload = async (bucketName, objectName, uploadId, eTags) => {
+      record.completedParts = eTags.map((e) => e.part)
+      return { etag: 'final-etag' }
+    }
+    return record
+  }
+
+  it('numbers a fresh multipart upload starting at part 1', async () => {
+    const client = makeClient()
+    const record = instrument(client)
+
+    await client.uploadStream('bucket', 'object', {}, bodyStream(3), partSize)
+
+    assert.deepEqual(record.sentPartNumbers, [1, 2, 3])
+    assert.deepEqual(record.completedParts, [1, 2, 3])
+  })
+
+  it('numbers re-uploaded parts consistently with skipped parts when resuming', async () => {
+    const client = makeClient()
+
+    // A prior upload already stored the first two (identical) chunks as parts 1 and 2.
+    const chunkETag = Crypto.createHash('md5').update(Buffer.alloc(partSize, 'x')).digest('hex')
+    const oldParts = [
+      { part: 1, etag: chunkETag },
+      { part: 2, etag: chunkETag },
+    ]
+    const record = instrument(client, oldParts)
+
+    await client.uploadStream('bucket', 'object', {}, bodyStream(3), partSize)
+
+    // parts 1 and 2 are skipped; only the third chunk is uploaded, as part 3.
+    assert.deepEqual(record.sentPartNumbers, [3])
+    assert.deepEqual(record.completedParts, [1, 2, 3])
+  })
+})

--- a/tests/unit/upload-stream-partnumber-test.js
+++ b/tests/unit/upload-stream-partnumber-test.js
@@ -99,4 +99,23 @@ describe('uploadStream multipart part numbering (#1482)', () => {
     assert.deepEqual(record.sentPartNumbers, [3])
     assert.deepEqual(record.completedParts, [1, 2, 3])
   })
+
+  it('re-uploads a mismatched old part at its own part number', async () => {
+    const client = makeClient()
+
+    // Part 1 still matches, but part 2's stored etag is stale, so the second
+    // chunk must be re-uploaded — at part 2, not shifted to part 3.
+    const matchingETag = Crypto.createHash('md5').update(Buffer.alloc(partSize, 'x')).digest('hex')
+    const oldParts = [
+      { part: 1, etag: matchingETag },
+      { part: 2, etag: 'stale-etag' },
+    ]
+    const record = instrument(client, oldParts)
+
+    await client.uploadStream('bucket', 'object', {}, bodyStream(3), partSize)
+
+    // part 1 skipped; part 2 re-uploaded at part 2 (not 3); part 3 uploaded.
+    assert.deepEqual(record.sentPartNumbers, [2, 3])
+    assert.deepEqual(record.completedParts, [1, 2, 3])
+  })
 })


### PR DESCRIPTION
## Problem

Fixes #1483 (and its duplicate #1482). In `uploadStream` (`src/internal/client.ts`) the multipart part counter is incremented **before** the part is uploaded, so the number sent to the server and pushed to `eTags` is one higher than the chunk's actual position:

```ts
let partNumber = 1
for await (const chunk of chunkier) {
  const oldPart = oldParts[partNumber]          // resume check uses the current number
  if (oldPart) {
    if (oldPart.etag === md5.toString('hex')) {
      eTags.push({ part: partNumber, etag: oldPart.etag })   // skip: current number
      partNumber++
      continue
    }
  }
  partNumber++                                   // upload: number bumped first
  const options = { query: qs.stringify({ partNumber, uploadId }), ... }
  ...
  eTags.push({ part: partNumber, etag })
}
```

Two consequences:

1. A fresh upload numbers its parts `2, 3, 4, …` instead of `1, 2, 3, …`. S3 tolerates a non-1 start as long as it is consistent, so this stays latent.
2. The skip branch records a chunk under `partNumber` while the upload branch records it under `partNumber + 1`. On a resumed upload that mixes skipped and re-uploaded chunks, the two branches disagree, producing gaps or duplicate part numbers in the `eTags` passed to `completeMultipartUpload` — a corrupted completion.

## Fix

Use the current `partNumber` for the upload and increment only after a successful part, so the skip and upload branches agree and numbering is 1-based.

## Tests

`tests/unit/upload-stream-partnumber-test.js` stubs the network-touching internals and drives `uploadStream`:

- a fresh 3-part upload now sends parts `[1, 2, 3]` (was `[2, 3, 4]`);
- a resume that already has parts 1 and 2 uploads only the third chunk, as part `3` (was `4`), so skipped and uploaded parts stay consistent.

Both fail before the change and pass after; the full `tests/unit` suite (176 tests) stays green.

## Note

This overlaps the stream loop touched by #1480 and #1481. #1481 (about unknown stream size) also happens to correct the counter but has been in `CHANGES_REQUESTED` for a while, and #1480 refactors the same loop while preserving the off-by-one. This PR is a minimal, standalone fix for the part-numbering bug with dedicated regression tests, independent of those changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed resumed multipart uploads to keep correct part numbering when some earlier parts are already present.
  - Ensured multipart completion reliably includes all parts in the correct order after resume scenarios.
- **Tests**
  - Added unit coverage for multipart resume behavior, including matching and mismatching previously uploaded parts, to prevent regressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->